### PR TITLE
Full suite of test vectors

### DIFF
--- a/interop/config.json
+++ b/interop/config.json
@@ -3,5 +3,12 @@
     "localhost:50001",
     "localhost:50002",
     "localhost:50003"
+  ],
+  "test_vectors": [
+    "tree_math",
+    "encryption",
+    "key_schedule",
+    "treekem",
+    "messages"
   ]
 }

--- a/interop/cpp-mock-client/Makefile
+++ b/interop/cpp-mock-client/Makefile
@@ -1,14 +1,14 @@
 BUILD_DIR=build
 APP_NAME=mock_client
 
-PHONY: all run format clean cclean
+.PHONY: all run format clean cclean
 
 all: ${BUILD_DIR}/${APP_NAME}
 
 ${BUILD_DIR}:
 	cmake -B${BUILD_DIR} .
 
-${BUILD_DIR}/${APP_NAME}: ${BUILD_DIR}
+${BUILD_DIR}/${APP_NAME}: ${BUILD_DIR} *.cpp
 	cmake --build ${BUILD_DIR} --target ${APP_NAME}
 
 run: ${BUILD_DIR}/${APP_NAME}

--- a/interop/cpp-mock-client/mock_client.cpp
+++ b/interop/cpp-mock-client/mock_client.cpp
@@ -1,7 +1,7 @@
-#include <memory>
-#include <string>
-#include <sstream>
 #include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
 
 #include <gflags/gflags.h>
 #include <grpcpp/grpcpp.h>
@@ -16,9 +16,9 @@ using grpc::StatusCode;
 using namespace mls_client;
 
 static constexpr char implementation_name[] = "Mock-C++";
-static constexpr std::array<uint32_t, 2> supported_ciphersuites = {0xA0A0, 0xA1A1};
-static constexpr TestVectorType test_vector_type = TestVectorType::TREE_MATH;
-static constexpr std::array<char, 4> test_vector = {0, 1, 2, 3};
+static constexpr std::array<uint32_t, 2> supported_ciphersuites = { 0xA0A0,
+                                                                    0xA1A1 };
+static constexpr std::array<char, 4> test_vector = { 0, 1, 2, 3 };
 
 class MLSClientImpl final : public MLSClient::Service
 {
@@ -33,9 +33,10 @@ class MLSClientImpl final : public MLSClient::Service
     return Status::OK;
   }
 
-  Status SupportedCiphersuites(ServerContext* /* context */,
-              const SupportedCiphersuitesRequest* /* request */,
-              SupportedCiphersuitesResponse* reply) override
+  Status SupportedCiphersuites(
+    ServerContext* /* context */,
+    const SupportedCiphersuitesRequest* /* request */,
+    SupportedCiphersuitesResponse* reply) override
   {
     std::cout << "Got SupportedCiphersuites request" << std::endl;
     reply->clear_ciphersuites();
@@ -46,12 +47,38 @@ class MLSClientImpl final : public MLSClient::Service
   }
 
   Status GenerateTestVector(ServerContext* /* context */,
-              const GenerateTestVectorRequest* request,
-              GenerateTestVectorResponse* reply) override
+                            const GenerateTestVectorRequest* request,
+                            GenerateTestVectorResponse* reply) override
   {
     std::cout << "Got GenerateTestVector request" << std::endl;
-    if (request->test_vector_type() != test_vector_type) {
-      return Status(StatusCode::INVALID_ARGUMENT, "Invalid test vector type");
+    switch (request->test_vector_type()) {
+      case TestVectorType::TREE_MATH: {
+        std::cout << "Tree math test vector request" << std::endl;
+        break;
+      }
+
+      case TestVectorType::ENCRYPTION: {
+        std::cout << "Encryption test vector request" << std::endl;
+        break;
+      }
+
+      case TestVectorType::KEY_SCHEDULE: {
+        std::cout << "Key schedule test vector request" << std::endl;
+        break;
+      }
+
+      case TestVectorType::TREEKEM: {
+        std::cout << "TreeKEM test vector request" << std::endl;
+        break;
+      }
+
+      case TestVectorType::MESSAGES: {
+        std::cout << "Messages test vector request" << std::endl;
+        break;
+      }
+
+      default:
+        return Status(StatusCode::INVALID_ARGUMENT, "Invalid test vector type");
     }
 
     std::cout << "  ... ok" << std::endl;
@@ -60,12 +87,38 @@ class MLSClientImpl final : public MLSClient::Service
   }
 
   Status VerifyTestVector(ServerContext* /* context */,
-              const VerifyTestVectorRequest* request,
-              VerifyTestVectorResponse* /* reply */) override
+                          const VerifyTestVectorRequest* request,
+                          VerifyTestVectorResponse* /* reply */) override
   {
     std::cout << "Got VerifyTestVector request" << std::endl;
-    if (request->test_vector_type() != test_vector_type) {
-      return Status(StatusCode::INVALID_ARGUMENT, "Invalid test vector type");
+    switch (request->test_vector_type()) {
+      case TestVectorType::TREE_MATH: {
+        std::cout << "Tree math test vector request" << std::endl;
+        break;
+      }
+
+      case TestVectorType::ENCRYPTION: {
+        std::cout << "Encryption test vector request" << std::endl;
+        break;
+      }
+
+      case TestVectorType::KEY_SCHEDULE: {
+        std::cout << "Key schedule test vector request" << std::endl;
+        break;
+      }
+
+      case TestVectorType::TREEKEM: {
+        std::cout << "TreeKEM test vector request" << std::endl;
+        break;
+      }
+
+      case TestVectorType::MESSAGES: {
+        std::cout << "Messages test vector request" << std::endl;
+        break;
+      }
+
+      default:
+        return Status(StatusCode::INVALID_ARGUMENT, "Invalid test vector type");
     }
 
     if (request->test_vector() != fixed_test_vector) {
@@ -74,15 +127,15 @@ class MLSClientImpl final : public MLSClient::Service
 
     return Status::OK;
   }
-
 };
 
-const std::string MLSClientImpl::fixed_test_vector = {test_vector.begin(), test_vector.end()};
+const std::string MLSClientImpl::fixed_test_vector = { test_vector.begin(),
+                                                       test_vector.end() };
 
 DEFINE_uint64(port, 50051, "Port to listen on");
 
 int
-main(int argc, char *argv[])
+main(int argc, char* argv[])
 {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 

--- a/interop/go-mock-client/main.go
+++ b/interop/go-mock-client/main.go
@@ -42,7 +42,23 @@ func (mc *MockClient) SupportedCiphersuites(ctx context.Context, req *pb.Support
 func (mc *MockClient) GenerateTestVector(ctx context.Context, req *pb.GenerateTestVectorRequest) (*pb.GenerateTestVectorResponse, error) {
 	log.Printf("Received GenerateTestVector request")
 
-	if req.TestVectorType != testVectorType {
+	switch req.TestVectorType {
+	case pb.TestVectorType_TREE_MATH:
+		log.Printf("Tree math test vector request")
+
+	case pb.TestVectorType_ENCRYPTION:
+		log.Printf("Encryption test vector request")
+
+	case pb.TestVectorType_KEY_SCHEDULE:
+		log.Printf("Key schedule test vector request")
+
+	case pb.TestVectorType_TREEKEM:
+		log.Printf("TreeKEM test vector request")
+
+	case pb.TestVectorType_MESSAGES:
+		log.Printf("Messages test vector request")
+
+	default:
 		return nil, status.Error(codes.InvalidArgument, "Invalid test vector type")
 	}
 
@@ -52,7 +68,23 @@ func (mc *MockClient) GenerateTestVector(ctx context.Context, req *pb.GenerateTe
 func (mc *MockClient) VerifyTestVector(ctx context.Context, req *pb.VerifyTestVectorRequest) (*pb.VerifyTestVectorResponse, error) {
 	log.Printf("Received VerifyTestVector request")
 
-	if req.TestVectorType != testVectorType {
+	switch req.TestVectorType {
+	case pb.TestVectorType_TREE_MATH:
+		log.Printf("Tree math test vector request")
+
+	case pb.TestVectorType_ENCRYPTION:
+		log.Printf("Encryption test vector request")
+
+	case pb.TestVectorType_KEY_SCHEDULE:
+		log.Printf("Key schedule test vector request")
+
+	case pb.TestVectorType_TREEKEM:
+		log.Printf("TreeKEM test vector request")
+
+	case pb.TestVectorType_MESSAGES:
+		log.Printf("Messages test vector request")
+
+	default:
 		return nil, status.Error(codes.InvalidArgument, "Invalid test vector type")
 	}
 

--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -34,13 +34,16 @@ message SupportedCiphersuitesResponse {
 // rpc GenerateTestVector
 enum TestVectorType {
   TREE_MATH = 0;
-  // TODO continue
+  ENCRYPTION = 1;
+  KEY_SCHEDULE = 2;
+  TREEKEM = 3;
+  MESSAGES = 4;
 }
 
 // Generation parameters that are not needed for a given test type are ignored
 message GenerateTestVectorRequest {
   TestVectorType test_vector_type = 1;
-  uint32 ciphersuite = 2; // Actually uint16
+  uint32 cipher_suite = 2; // Actually uint16
   uint32 n_leaves = 3;
   uint32 n_generations = 4;
   uint32 n_epochs = 5;

--- a/interop/rust-mock-client/src/main.rs
+++ b/interop/rust-mock-client/src/main.rs
@@ -105,7 +105,6 @@ impl MlsClient for MlsClientImpl {
         println!("{} test vector request", type_msg);
 
         if (obj.test_vector != TEST_VECTOR) {
-            println!("{:?} != {:?}", obj.test_vector, TEST_VECTOR);
             return Err(tonic::Status::new(tonic::Code::InvalidArgument, "Invalid test vector"))
         }
 

--- a/interop/rust-mock-client/src/main.rs
+++ b/interop/rust-mock-client/src/main.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use tonic::{transport::Server, Request, Response, Status};
 use clap::Clap;
 
@@ -14,8 +15,22 @@ pub mod mls_client {
 
 const IMPLEMENTATION_NAME: &str = "Mock-Rust";
 const SUPPORTED_CIPHERSUITES: [u32; 2] = [0xA0A0, 0xA1A1];
-const TEST_VECTOR_TYPE: TestVectorType = TestVectorType::TreeMath;
 const TEST_VECTOR: [u8; 4] = [0, 1, 2, 3];
+
+impl TryFrom<i32> for TestVectorType {
+    type Error = ();
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(TestVectorType::TreeMath),
+            1 => Ok(TestVectorType::Encryption),
+            2 => Ok(TestVectorType::KeySchedule),
+            3 => Ok(TestVectorType::Treekem),
+            4 => Ok(TestVectorType::Messages),
+            _ => Err(()),
+        }
+    }
+}
 
 #[derive(Default)]
 pub struct MlsClientImpl {}
@@ -51,9 +66,17 @@ impl MlsClient for MlsClientImpl {
         println!("Got GenerateTestVector request");
 
         let obj = request.get_ref();
-        if (obj.test_vector_type != TEST_VECTOR_TYPE as i32) {
-            return Err(tonic::Status::new(tonic::Code::InvalidArgument, "Invalid test vector type"))
-        }
+        let type_msg = match TestVectorType::try_from(obj.test_vector_type) {
+            Ok(TestVectorType::TreeMath) => "Tree math",
+            Ok(TestVectorType::Encryption) => "Encryption",
+            Ok(TestVectorType::KeySchedule) => "Key Schedule",
+            Ok(TestVectorType::Treekem) => "TreeKEM",
+            Ok(TestVectorType::Messages) => "Messages",
+            Err(_) => {
+                return Err(tonic::Status::new(tonic::Code::InvalidArgument, "Invalid test vector type"));
+            }
+        };
+        println!("{} test vector request", type_msg);
 
         let response = GenerateTestVectorResponse {
             test_vector: TEST_VECTOR.to_vec(),
@@ -69,11 +92,20 @@ impl MlsClient for MlsClientImpl {
         println!("Got VerifyTestVector request");
 
         let obj = request.get_ref();
-        if (obj.test_vector_type != TEST_VECTOR_TYPE as i32) {
-            return Err(tonic::Status::new(tonic::Code::InvalidArgument, "Invalid test vector type"))
-        }
+        let type_msg = match TestVectorType::try_from(obj.test_vector_type) {
+            Ok(TestVectorType::TreeMath) => "Tree math",
+            Ok(TestVectorType::Encryption) => "Encryption",
+            Ok(TestVectorType::KeySchedule) => "Key Schedule",
+            Ok(TestVectorType::Treekem) => "TreeKEM",
+            Ok(TestVectorType::Messages) => "Messages",
+            Err(_) => {
+                return Err(tonic::Status::new(tonic::Code::InvalidArgument, "Invalid test vector type"));
+            }
+        };
+        println!("{} test vector request", type_msg);
 
         if (obj.test_vector != TEST_VECTOR) {
+            println!("{:?} != {:?}", obj.test_vector, TEST_VECTOR);
             return Err(tonic::Status::new(tonic::Code::InvalidArgument, "Invalid test vector"))
         }
 

--- a/interop/test-runner/main.go
+++ b/interop/test-runner/main.go
@@ -147,10 +147,10 @@ func main() {
 		log.Printf("Connected to [%s] @ [%s]", clients[i].name, addr)
 	}
 
-	// Build a ciphersuite compatibility matrix.  Entry `i` is the set of suites
-	// that client `i` has in common with any other client.  This tells us what
-	// cases that client needs to generate in order to test all cases with other
-	// clients.
+	// Build a ciphersuite compatibility matrix.  Each client's `compat` set
+	// contains the ciphersuites that it shares with *any* other client under
+	// test.  This tells us what cases that client needs to generate in order to
+	// test all cases with other clients.
 	for _, client := range clients {
 		for _, other := range clients {
 			client.AddCompat(other)

--- a/test-vectors.md
+++ b/test-vectors.md
@@ -5,6 +5,32 @@ MLS stack.  Each test harness should have a way to produce and verify test
 vectors of a few kinds.  In this document we specify the format for test vectors
 and how they are verified.
 
+The idea here is to test the cryptographic operations underlying MLS without the
+complexity of the full protocol.  We tackle the overall cryptographic operation
+in pieces:
+
+```
+                           epoch_secret
+                                |
+|\ Ratchet                      |                            Secret /|
+| \ Tree                        |                             Tree / |
+|  \                            |                                 /  |
+|   \                           V                                /   |
+|    --> commit_secret --> epoch_secret --> encryption_secret -->    |
+|   /                           |                                \   |
+|  /                            |                                 \  |
+| /                             |                                  \ |
+|/                              |                                   \|
+                                V
+                           epoch_secret
+
+<-------------> <----------------------------------> <--------------->
+    TreeKEM                KeySchedule                   Encryption
+```
+
+The `TreeMath` and `Messages` testvectors verify basic tree math operations and
+the syntax of the messages used for MLS (independent of semantics).
+
 ## Tree Math
 
 Parameters:


### PR DESCRIPTION
This PR adds support for the full suite of test vectors across the proto file and client stubs.  The test runner can now also be configured to run test vector interop tests across clients, including ciphersuite compatibility.