### PR TITLE
update treemath and encryption test vector description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+interop/cpp-mock-client/build/


### PR DESCRIPTION
This is the result of the discussion in https://github.com/mlswg/mls-implementations/issues/32
and changes tree math and encryption test vectors accordingly.

Note that the representation section currently only applies to these two sections.

fixes #32 