### PR TITLE
Complete gRPC definitions

### DIFF
--- a/interop/cpp-mock-client/mock_client.cpp
+++ b/interop/cpp-mock-client/mock_client.cpp
@@ -127,6 +127,134 @@ class MLSClientImpl final : public MLSClient::Service
 
     return Status::OK;
   }
+
+  // Ways to become a member of a group
+  Status CreateGroup(ServerContext* /* context */,
+                     const CreateGroupRequest* /* request */,
+                     CreateGroupResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status CreateKeyPackage(ServerContext* /* context */,
+                          const CreateKeyPackageRequest* /* request */,
+                          CreateKeyPackageResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status JoinGroup(ServerContext* /* context */,
+                   const JoinGroupRequest* /* request */,
+                   JoinGroupResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status ExternalJoin(ServerContext* /* context */,
+                      const ExternalJoinRequest* /* request */,
+                      ExternalJoinResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  // Operations using a group state
+  Status PublicGroupState(ServerContext* /* context */,
+                          const PublicGroupStateRequest* /* request */,
+                          PublicGroupStateResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status StateAuth(ServerContext* /* context */,
+                   const StateAuthRequest* /* request */,
+                   StateAuthResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status Export(ServerContext* /* context */,
+                const ExportRequest* /* request */,
+                ExportResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status Protect(ServerContext* /* context */,
+                 const ProtectRequest* /* request */,
+                 ProtectResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status Unprotect(ServerContext* /* context */,
+                   const UnprotectRequest* /* request */,
+                   UnprotectResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status StorePSK(ServerContext* /* context */,
+                  const StorePSKRequest* /* request */,
+                  StorePSKResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status AddProposal(ServerContext* /* context */,
+                     const AddProposalRequest* /* request */,
+                     ProposalResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status UpdateProposal(ServerContext* /* context */,
+                        const UpdateProposalRequest* /* request */,
+                        ProposalResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status RemoveProposal(ServerContext* /* context */,
+                        const RemoveProposalRequest* /* request */,
+                        ProposalResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status PSKProposal(ServerContext* /* context */,
+                     const PSKProposalRequest* /* request */,
+                     ProposalResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status ReInitProposal(ServerContext* /* context */,
+                        const ReInitProposalRequest* /* request */,
+                        ProposalResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status AppAckProposal(ServerContext* /* context */,
+                        const AppAckProposalRequest* /* request */,
+                        ProposalResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status Commit(ServerContext* /* context */,
+                const CommitRequest* /* request */,
+                CommitResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
+
+  Status HandleCommit(ServerContext* /* context */,
+                      const HandleCommitRequest* /* request */,
+                      HandleCommitResponse* /* response */) override
+  {
+    return Status::OK; // TODO
+  }
 };
 
 const std::string MLSClientImpl::fixed_test_vector = { test_vector.begin(),

--- a/interop/go-mock-client/main.go
+++ b/interop/go-mock-client/main.go
@@ -95,6 +95,80 @@ func (mc *MockClient) VerifyTestVector(ctx context.Context, req *pb.VerifyTestVe
 	return &pb.VerifyTestVectorResponse{}, nil
 }
 
+// Ways to become a member of a group
+func (mc *MockClient) CreateGroup(ctx context.Context, in *pb.CreateGroupRequest) (*pb.CreateGroupResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) CreateKeyPackage(ctx context.Context, in *pb.CreateKeyPackageRequest) (*pb.CreateKeyPackageResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) JoinGroup(ctx context.Context, in *pb.JoinGroupRequest) (*pb.JoinGroupResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) ExternalJoin(ctx context.Context, in *pb.ExternalJoinRequest) (*pb.ExternalJoinResponse, error) {
+	return nil, nil // TODO
+}
+
+// Operations using a group state
+func (mc *MockClient) PublicGroupState(ctx context.Context, in *pb.PublicGroupStateRequest) (*pb.PublicGroupStateResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) StateAuth(ctx context.Context, in *pb.StateAuthRequest) (*pb.StateAuthResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) Export(ctx context.Context, in *pb.ExportRequest) (*pb.ExportResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) Protect(ctx context.Context, in *pb.ProtectRequest) (*pb.ProtectResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) Unprotect(ctx context.Context, in *pb.UnprotectRequest) (*pb.UnprotectResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) StorePSK(ctx context.Context, in *pb.StorePSKRequest) (*pb.StorePSKResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) AddProposal(ctx context.Context, in *pb.AddProposalRequest) (*pb.ProposalResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) UpdateProposal(ctx context.Context, in *pb.UpdateProposalRequest) (*pb.ProposalResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) RemoveProposal(ctx context.Context, in *pb.RemoveProposalRequest) (*pb.ProposalResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) PSKProposal(ctx context.Context, in *pb.PSKProposalRequest) (*pb.ProposalResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) ReInitProposal(ctx context.Context, in *pb.ReInitProposalRequest) (*pb.ProposalResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) AppAckProposal(ctx context.Context, in *pb.AppAckProposalRequest) (*pb.ProposalResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) Commit(ctx context.Context, in *pb.CommitRequest) (*pb.CommitResponse, error) {
+	return nil, nil // TODO
+}
+
+func (mc *MockClient) HandleCommit(ctx context.Context, in *pb.HandleCommitRequest) (*pb.HandleCommitResponse, error) {
+	return nil, nil // TODO
+}
+
 ///
 /// Run the server
 ///

--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -15,6 +15,30 @@ service MLSClient {
   // Test vector generation and verification
   rpc GenerateTestVector(GenerateTestVectorRequest) returns (GenerateTestVectorResponse) {}
   rpc VerifyTestVector(VerifyTestVectorRequest) returns (VerifyTestVectorResponse) {}
+
+  // Ways to become a member of a group
+  rpc CreateGroup(CreateGroupRequest) returns (CreateGroupResponse) {}
+  rpc CreateKeyPackage(CreateKeyPackageRequest) returns (CreateKeyPackageResponse) {}
+  rpc JoinGroup(JoinGroupRequest) returns (JoinGroupResponse) {}
+  rpc ExternalJoin(ExternalJoinRequest) returns (ExternalJoinResponse) {}
+
+  // Operations using a group state
+  rpc PublicGroupState(PublicGroupStateRequest) returns (PublicGroupStateResponse) {}
+  rpc StateAuth(StateAuthRequest) returns (StateAuthResponse) {}
+  rpc Export(ExportRequest) returns (ExportResponse) {}
+  rpc Protect(ProtectRequest) returns (ProtectResponse) {}
+  rpc Unprotect(UnprotectRequest) returns (UnprotectResponse) {}
+  rpc StorePSK(StorePSKRequest) returns (StorePSKResponse) {}
+  
+  rpc AddProposal(AddProposalRequest) returns (ProposalResponse) {}
+  rpc UpdateProposal(UpdateProposalRequest) returns (ProposalResponse) {}
+  rpc RemoveProposal(RemoveProposalRequest) returns (ProposalResponse) {}
+  rpc PSKProposal(PSKProposalRequest) returns (ProposalResponse) {}
+  rpc ReInitProposal(ReInitProposalRequest) returns (ProposalResponse) {}
+  rpc AppAckProposal(AppAckProposalRequest) returns (ProposalResponse) {}
+  
+  rpc Commit(CommitRequest) returns (CommitResponse) {}
+  rpc HandleCommit(HandleCommitRequest) returns (HandleCommitResponse) {}
 }
 
 // rpc Name
@@ -60,3 +84,170 @@ message VerifyTestVectorRequest {
 }
 
 message VerifyTestVectorResponse {}
+
+
+// rpc CreateGroup
+// XXX(RLB): Credential type is omitted; let's just use Basic for these tests
+message CreateGroupRequest { 
+  bytes group_id = 1;
+  uint32 cipher_suite = 2; // Actually uint16
+  bool encrypt_handshake = 3; 
+}
+
+message CreateGroupResponse {
+  uint32 state_id = 1;
+}
+
+// rpc CreateKeyPackage
+message CreateKeyPackageRequest {
+  uint32 cipher_suite = 1;
+}
+
+message CreateKeyPackageResponse {
+  uint32 transaction_id = 1;
+  bytes key_package = 2;
+}
+
+// rpc JoinGroup
+message JoinGroupRequest {
+  uint32 transaction_id = 1;
+  bytes welcome = 2;
+  bool encrypt_handshake = 3;
+}
+
+message JoinGroupResponse { 
+  uint32 state_id = 1;
+}
+
+// rpc ExternalJoin
+message ExternalJoinRequest {
+  bytes public_group_state = 1;
+  bool encrypt_handshake = 2;
+}
+
+message ExternalJoinResponse {
+  bytes commit = 1;
+  bytes welcome = 2;
+  uint32 state_id = 3;
+}
+
+// rpc PublicGroupState
+message PublicGroupStateRequest {
+  uint32 state_id = 1;
+}
+
+message PublicGroupStateResponse {
+  bytes public_group_state = 1;
+}
+
+// rpc StateAuth
+message StateAuthRequest {
+  uint32 state_id = 1;
+}
+
+message StateAuthResponse {
+  bytes state_auth_secret = 1;
+}
+
+// rpc Export
+message ExportRequest {
+  uint32 state_id = 1;
+  string label = 2;
+  bytes context = 3;
+  uint32 key_length = 4;
+}
+
+message ExportResponse {
+  bytes exported_secret = 1;
+}
+
+// rpc Protect
+message ProtectRequest {
+  uint32 state_id = 1;
+  bytes application_data = 2;
+}
+
+message ProtectResponse { 
+  bytes ciphertext = 1;
+}
+
+// rpc Unprotect
+message UnprotectRequest {
+  uint32 state_id = 1;
+  bytes ciphertext = 2;
+}
+
+message UnprotectResponse {
+  bytes application_data = 1;
+}
+
+// rpc StorePSK
+message StorePSKRequest {
+  uint32 state_id = 1;
+  bytes psk_id = 2;
+  bytes psk = 3;
+}
+
+message StorePSKResponse {}
+
+// rpc AddProposal
+message AddProposalRequest {
+  uint32 state_id = 1;
+  bytes key_package = 2;
+}
+
+message ProposalResponse {
+  bytes proposal = 1;
+}
+
+// rpc UpdateProposal
+message UpdateProposalRequest {
+  uint32 state_id = 1;
+}
+
+// rpc RemoveProposal
+message RemoveProposalRequest {
+  uint32 state_id = 1;
+  uint32 removed = 2;
+}
+
+// rpc PSKProposal
+message PSKProposalRequest {
+  uint32 state_id = 1;
+  bytes psk_id = 2;
+}
+
+// rpc ReInitProposal
+message ReInitProposalRequest {
+  uint32 state_id = 1;
+  bytes group_id = 2;
+  uint32 cipher_suite = 3; // actually uint16
+}
+
+// rpc AppAckProposal
+message AppAckProposalRequest {
+  uint32 state_id = 1;
+}
+
+// rpc Commit
+message CommitRequest {
+  uint32 state_id = 1;
+  repeated bytes by_reference = 2;
+  repeated bytes by_value = 3;
+}
+
+message CommitResponse {
+  repeated bytes proposal = 1;
+  bytes commit = 2;
+}
+
+// rpc HandleCommit
+message HandleCommitRequest {
+  uint32 state_id = 1;
+  repeated bytes proposal = 2;
+  bytes commit = 3;
+}
+
+message HandleCommitResponse { 
+  uint32 state_id = 1;
+}

--- a/interop/rust-mock-client/src/main.rs
+++ b/interop/rust-mock-client/src/main.rs
@@ -1,13 +1,10 @@
+use clap::Clap;
 use std::convert::TryFrom;
 use tonic::{transport::Server, Request, Response, Status};
-use clap::Clap;
 
 use mls_client::mls_client_server::{MlsClient, MlsClientServer};
-use mls_client::TestVectorType;
-use mls_client::{GenerateTestVectorRequest, GenerateTestVectorResponse};
-use mls_client::{NameRequest, NameResponse};
-use mls_client::{SupportedCiphersuitesRequest, SupportedCiphersuitesResponse};
-use mls_client::{VerifyTestVectorRequest, VerifyTestVectorResponse};
+// TODO(RLB) Convert this back to more specific `use` directives
+use mls_client::*;
 
 pub mod mls_client {
     tonic::include_proto!("mls_client");
@@ -73,7 +70,10 @@ impl MlsClient for MlsClientImpl {
             Ok(TestVectorType::Treekem) => "TreeKEM",
             Ok(TestVectorType::Messages) => "Messages",
             Err(_) => {
-                return Err(tonic::Status::new(tonic::Code::InvalidArgument, "Invalid test vector type"));
+                return Err(tonic::Status::new(
+                    tonic::Code::InvalidArgument,
+                    "Invalid test vector type",
+                ));
             }
         };
         println!("{} test vector request", type_msg);
@@ -99,25 +99,157 @@ impl MlsClient for MlsClientImpl {
             Ok(TestVectorType::Treekem) => "TreeKEM",
             Ok(TestVectorType::Messages) => "Messages",
             Err(_) => {
-                return Err(tonic::Status::new(tonic::Code::InvalidArgument, "Invalid test vector type"));
+                return Err(tonic::Status::new(
+                    tonic::Code::InvalidArgument,
+                    "Invalid test vector type",
+                ));
             }
         };
         println!("{} test vector request", type_msg);
 
         if (obj.test_vector != TEST_VECTOR) {
-            return Err(tonic::Status::new(tonic::Code::InvalidArgument, "Invalid test vector"))
+            return Err(tonic::Status::new(
+                tonic::Code::InvalidArgument,
+                "Invalid test vector",
+            ));
         }
 
         Ok(Response::new(VerifyTestVectorResponse::default()))
+    }
+
+    async fn create_group(
+        &self,
+        _request: tonic::Request<CreateGroupRequest>,
+    ) -> Result<tonic::Response<CreateGroupResponse>, tonic::Status> {
+        Ok(Response::new(CreateGroupResponse::default())) // TODO
+    }
+
+    async fn create_key_package(
+        &self,
+        _request: tonic::Request<CreateKeyPackageRequest>,
+    ) -> Result<tonic::Response<CreateKeyPackageResponse>, tonic::Status> {
+        Ok(Response::new(CreateKeyPackageResponse::default())) // TODO
+    }
+
+    async fn join_group(
+        &self,
+        _request: tonic::Request<JoinGroupRequest>,
+    ) -> Result<tonic::Response<JoinGroupResponse>, tonic::Status> {
+        Ok(Response::new(JoinGroupResponse::default())) // TODO
+    }
+
+    async fn external_join(
+        &self,
+        _request: tonic::Request<ExternalJoinRequest>,
+    ) -> Result<tonic::Response<ExternalJoinResponse>, tonic::Status> {
+        Ok(Response::new(ExternalJoinResponse::default())) // TODO
+    }
+
+    async fn public_group_state(
+        &self,
+        _request: tonic::Request<PublicGroupStateRequest>,
+    ) -> Result<tonic::Response<PublicGroupStateResponse>, tonic::Status> {
+        Ok(Response::new(PublicGroupStateResponse::default())) // TODO
+    }
+
+    async fn state_auth(
+        &self,
+        _request: tonic::Request<StateAuthRequest>,
+    ) -> Result<tonic::Response<StateAuthResponse>, tonic::Status> {
+        Ok(Response::new(StateAuthResponse::default())) // TODO
+    }
+
+    async fn export(
+        &self,
+        _request: tonic::Request<ExportRequest>,
+    ) -> Result<tonic::Response<ExportResponse>, tonic::Status> {
+        Ok(Response::new(ExportResponse::default())) // TODO
+    }
+
+    async fn protect(
+        &self,
+        _request: tonic::Request<ProtectRequest>,
+    ) -> Result<tonic::Response<ProtectResponse>, tonic::Status> {
+        Ok(Response::new(ProtectResponse::default())) // TODO
+    }
+
+    async fn unprotect(
+        &self,
+        _request: tonic::Request<UnprotectRequest>,
+    ) -> Result<tonic::Response<UnprotectResponse>, tonic::Status> {
+        Ok(Response::new(UnprotectResponse::default())) // TODO
+    }
+
+    async fn store_psk(
+        &self,
+        _request: tonic::Request<StorePskRequest>,
+    ) -> Result<tonic::Response<StorePskResponse>, tonic::Status> {
+        Ok(Response::new(StorePskResponse::default())) // TODO
+    }
+
+    async fn add_proposal(
+        &self,
+        _request: tonic::Request<AddProposalRequest>,
+    ) -> Result<tonic::Response<ProposalResponse>, tonic::Status> {
+        Ok(Response::new(ProposalResponse::default())) // TODO
+    }
+
+    async fn update_proposal(
+        &self,
+        _request: tonic::Request<UpdateProposalRequest>,
+    ) -> Result<tonic::Response<ProposalResponse>, tonic::Status> {
+        Ok(Response::new(ProposalResponse::default())) // TODO
+    }
+
+    async fn remove_proposal(
+        &self,
+        _request: tonic::Request<RemoveProposalRequest>,
+    ) -> Result<tonic::Response<ProposalResponse>, tonic::Status> {
+        Ok(Response::new(ProposalResponse::default())) // TODO
+    }
+
+    async fn psk_proposal(
+        &self,
+        _request: tonic::Request<PskProposalRequest>,
+    ) -> Result<tonic::Response<ProposalResponse>, tonic::Status> {
+        Ok(Response::new(ProposalResponse::default())) // TODO
+    }
+
+    async fn re_init_proposal(
+        &self,
+        _request: tonic::Request<ReInitProposalRequest>,
+    ) -> Result<tonic::Response<ProposalResponse>, tonic::Status> {
+        Ok(Response::new(ProposalResponse::default())) // TODO
+    }
+
+    async fn app_ack_proposal(
+        &self,
+        _request: tonic::Request<AppAckProposalRequest>,
+    ) -> Result<tonic::Response<ProposalResponse>, tonic::Status> {
+        Ok(Response::new(ProposalResponse::default())) // TODO
+    }
+
+    async fn commit(
+        &self,
+        _request: tonic::Request<CommitRequest>,
+    ) -> Result<tonic::Response<CommitResponse>, tonic::Status> {
+        Ok(Response::new(CommitResponse::default())) // TODO
+    }
+
+    async fn handle_commit(
+        &self,
+        _request: tonic::Request<HandleCommitRequest>,
+    ) -> Result<tonic::Response<HandleCommitResponse>, tonic::Status> {
+        Ok(Response::new(HandleCommitResponse::default())) // TODO
     }
 }
 
 #[derive(Clap)]
 struct Opts {
-    #[clap(short, long, default_value="[::1]")]
+    #[clap(short, long, default_value = "[::1]")]
     host: String,
 
-    #[clap(short, long, default_value="50051")]
+    #[clap(short, long, default_value = "50051")]
     port: u16,
 }
 

--- a/test-harness.md
+++ b/test-harness.md
@@ -62,6 +62,9 @@ One pair of such methods for each test vector type (parameters):
 
 ### Operations using a group state:
 
+* Get PublicGroupState
+  * Inputs: (none)
+  * Outputs: PublicGroupState
 * Get state auth
   * Inputs: (none)
   * Outputs: authentication_secret


### PR DESCRIPTION
This PR extends the definend gRPC interface to cover all the methods described in `test-harness.md`, and adds stub methods to the mock clients.