### PR TITLE
Add interop test scripts

### DIFF
--- a/interop/config.json
+++ b/interop/config.json
@@ -11,5 +11,16 @@
     "transcript",
     "treekem",
     "messages"
-  ]
+  ],
+  "script": {
+    "two_person": [
+      {"actor": "alice", "action": "create_group"},
+      {"actor": "bob", "action": "create_key_package"},
+      {"actor": "alice", "action": "add_proposal", "key_package": 1},
+      {"actor": "alice", "action": "commit", "by_reference": [2]},
+      {"actor": "bob", "action": "join", "welcome": 3},
+      {"actor": "alice", "action": "handle_commit", "by_reference": [2], "commit": 3},
+      {"actor": "*", "action": "verify_state_auth"}
+    ]
+  }
 }

--- a/interop/config.json
+++ b/interop/config.json
@@ -16,10 +16,10 @@
     "two_person": [
       {"actor": "alice", "action": "create_group"},
       {"actor": "bob", "action": "create_key_package"},
-      {"actor": "alice", "action": "add_proposal", "key_package": 1},
-      {"actor": "alice", "action": "commit", "by_reference": [2]},
-      {"actor": "bob", "action": "join", "welcome": 3},
-      {"actor": "alice", "action": "handle_commit", "by_reference": [2], "commit": 3},
+      {"actor": "alice", "action": "add_proposal", "keyPackage": 1},
+      {"actor": "alice", "action": "commit", "byReference": [2]},
+      {"actor": "bob", "action": "join_group", "welcome": 3},
+      {"actor": "alice", "action": "handle_commit", "byReference": [2], "commit": 3},
       {"actor": "*", "action": "verify_state_auth"}
     ]
   }

--- a/interop/config.json
+++ b/interop/config.json
@@ -12,7 +12,7 @@
     "treekem",
     "messages"
   ],
-  "script": {
+  "scripts": {
     "two_person": [
       {"actor": "alice", "action": "create_group"},
       {"actor": "bob", "action": "create_key_package"},

--- a/interop/config.json
+++ b/interop/config.json
@@ -14,13 +14,13 @@
   ],
   "scripts": {
     "two_person": [
-      {"actor": "alice", "action": "create_group"},
-      {"actor": "bob", "action": "create_key_package"},
-      {"actor": "alice", "action": "add_proposal", "keyPackage": 1},
-      {"actor": "alice", "action": "commit", "byReference": [2]},
-      {"actor": "bob", "action": "join_group", "welcome": 3},
-      {"actor": "alice", "action": "handle_commit", "byReference": [2], "commit": 3},
-      {"actor": "*", "action": "verify_state_auth"}
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "createKeyPackage", "actor": "bob"},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 1},
+      {"action": "commit", "actor": "alice", "byReference": [2]},
+      {"action": "joinGroup", "actor": "bob", "welcome": 3},
+      {"action": "handleCommit", "actor": "alice", "byReference": [2], "commit": 3},
+      {"action": "verifyStateAuth"}
     ]
   }
 }

--- a/interop/cpp-mock-client/mock_client.cpp
+++ b/interop/cpp-mock-client/mock_client.cpp
@@ -151,15 +151,20 @@ class MLSClientImpl final : public MLSClient::Service
 
   Status CreateKeyPackage(ServerContext* /* context */,
                           const CreateKeyPackageRequest* /* request */,
-                          CreateKeyPackageResponse* /* response */) override
+                          CreateKeyPackageResponse* response) override
   {
+    response->set_key_package("keyPackage");
     return Status::OK; // TODO
   }
 
   Status JoinGroup(ServerContext* /* context */,
-                   const JoinGroupRequest* /* request */,
+                   const JoinGroupRequest* request,
                    JoinGroupResponse* /* response */) override
   {
+    if (request->welcome() != "welcome") {
+      return Status(StatusCode::INVALID_ARGUMENT, "Invalid welcome");
+    }
+
     return Status::OK; // TODO
   }
 
@@ -180,8 +185,9 @@ class MLSClientImpl final : public MLSClient::Service
 
   Status StateAuth(ServerContext* /* context */,
                    const StateAuthRequest* /* request */,
-                   StateAuthResponse* /* response */) override
+                   StateAuthResponse* response) override
   {
+    response->set_state_auth_secret("stateAuthSecret");
     return Status::OK; // TODO
   }
 
@@ -214,9 +220,14 @@ class MLSClientImpl final : public MLSClient::Service
   }
 
   Status AddProposal(ServerContext* /* context */,
-                     const AddProposalRequest* /* request */,
-                     ProposalResponse* /* response */) override
+                     const AddProposalRequest* request,
+                     ProposalResponse* response) override
   {
+    if (request->key_package() != "keyPackage") {
+      return Status(StatusCode::INVALID_ARGUMENT, "Invalid commit");
+    }
+
+    response->set_proposal("addProposal");
     return Status::OK; // TODO
   }
 
@@ -257,15 +268,21 @@ class MLSClientImpl final : public MLSClient::Service
 
   Status Commit(ServerContext* /* context */,
                 const CommitRequest* /* request */,
-                CommitResponse* /* response */) override
+                CommitResponse* response) override
   {
+    response->set_commit("commit");
+    response->set_welcome("welcome");
     return Status::OK; // TODO
   }
 
   Status HandleCommit(ServerContext* /* context */,
-                      const HandleCommitRequest* /* request */,
+                      const HandleCommitRequest* request,
                       HandleCommitResponse* /* response */) override
   {
+    if (request->commit() != "commit") {
+      return Status(StatusCode::INVALID_ARGUMENT, "Invalid commit");
+    }
+
     return Status::OK; // TODO
   }
 };

--- a/interop/cpp-mock-client/mock_client.cpp
+++ b/interop/cpp-mock-client/mock_client.cpp
@@ -50,43 +50,44 @@ class MLSClientImpl final : public MLSClient::Service
                             const GenerateTestVectorRequest* request,
                             GenerateTestVectorResponse* reply) override
   {
-    std::cout << "Got GenerateTestVector request" << std::endl;
+    std::cout << "Got GenerateTestVector request: ";
     switch (request->test_vector_type()) {
       case TestVectorType::TREE_MATH: {
-        std::cout << "Tree math test vector request" << std::endl;
+        std::cout << "Tree math" << std::endl;
         break;
       }
 
       case TestVectorType::ENCRYPTION: {
-        std::cout << "Encryption test vector request" << std::endl;
+        std::cout << "Encryption" << std::endl;
         break;
       }
 
       case TestVectorType::KEY_SCHEDULE: {
-        std::cout << "Key schedule test vector request" << std::endl;
+        std::cout << "Key schedule" << std::endl;
         break;
       }
 
       case TestVectorType::TRANSCRIPT: {
-        std::cout << "Transcript test vector request" << std::endl;
+        std::cout << "Transcript" << std::endl;
         break;
       }
 
       case TestVectorType::TREEKEM: {
-        std::cout << "TreeKEM test vector request" << std::endl;
+        std::cout << "TreeKEM" << std::endl;
         break;
       }
 
       case TestVectorType::MESSAGES: {
-        std::cout << "Messages test vector request" << std::endl;
+        std::cout << "Messages" << std::endl;
         break;
       }
 
-      default:
+      default: {
+        std::cout << "Invalid" << std::endl;
         return Status(StatusCode::INVALID_ARGUMENT, "Invalid test vector type");
+      }
     }
 
-    std::cout << "  ... ok" << std::endl;
     reply->set_test_vector(fixed_test_vector);
     return Status::OK;
   }
@@ -95,40 +96,42 @@ class MLSClientImpl final : public MLSClient::Service
                           const VerifyTestVectorRequest* request,
                           VerifyTestVectorResponse* /* reply */) override
   {
-    std::cout << "Got VerifyTestVector request" << std::endl;
+    std::cout << "Got VerifyTestVector request: ";
     switch (request->test_vector_type()) {
       case TestVectorType::TREE_MATH: {
-        std::cout << "Tree math test vector request" << std::endl;
+        std::cout << "Tree math" << std::endl;
         break;
       }
 
       case TestVectorType::ENCRYPTION: {
-        std::cout << "Encryption test vector request" << std::endl;
+        std::cout << "Encryption" << std::endl;
         break;
       }
 
       case TestVectorType::KEY_SCHEDULE: {
-        std::cout << "Key schedule test vector request" << std::endl;
+        std::cout << "Key schedule" << std::endl;
         break;
       }
 
       case TestVectorType::TRANSCRIPT: {
-        std::cout << "Transcript test vector request" << std::endl;
+        std::cout << "Transcript" << std::endl;
         break;
       }
 
       case TestVectorType::TREEKEM: {
-        std::cout << "TreeKEM test vector request" << std::endl;
+        std::cout << "TreeKEM" << std::endl;
         break;
       }
 
       case TestVectorType::MESSAGES: {
-        std::cout << "Messages test vector request" << std::endl;
+        std::cout << "Messages" << std::endl;
         break;
       }
 
-      default:
+      default: {
+        std::cout << "Invalid" << std::endl;
         return Status(StatusCode::INVALID_ARGUMENT, "Invalid test vector type");
+      }
     }
 
     if (request->test_vector() != fixed_test_vector) {

--- a/interop/go-mock-client/main.go
+++ b/interop/go-mock-client/main.go
@@ -102,76 +102,119 @@ func (mc *MockClient) VerifyTestVector(ctx context.Context, req *pb.VerifyTestVe
 
 // Ways to become a member of a group
 func (mc *MockClient) CreateGroup(ctx context.Context, in *pb.CreateGroupRequest) (*pb.CreateGroupResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.CreateGroupResponse{}
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) CreateKeyPackage(ctx context.Context, in *pb.CreateKeyPackageRequest) (*pb.CreateKeyPackageResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.CreateKeyPackageResponse{
+		KeyPackage: []byte("keyPackage"),
+	}
+
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) JoinGroup(ctx context.Context, in *pb.JoinGroupRequest) (*pb.JoinGroupResponse, error) {
-	return nil, nil // TODO
+	if string(in.Welcome) != "welcome" {
+		return nil, status.Error(codes.InvalidArgument, "Invalid welcome")
+	}
+
+	resp := &pb.JoinGroupResponse{}
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) ExternalJoin(ctx context.Context, in *pb.ExternalJoinRequest) (*pb.ExternalJoinResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.ExternalJoinResponse{}
+	return resp, nil // TODO
 }
 
 // Operations using a group state
 func (mc *MockClient) PublicGroupState(ctx context.Context, in *pb.PublicGroupStateRequest) (*pb.PublicGroupStateResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.PublicGroupStateResponse{}
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) StateAuth(ctx context.Context, in *pb.StateAuthRequest) (*pb.StateAuthResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.StateAuthResponse{
+		StateAuthSecret: []byte("stateAuthSecret"),
+	}
+
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) Export(ctx context.Context, in *pb.ExportRequest) (*pb.ExportResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.ExportResponse{}
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) Protect(ctx context.Context, in *pb.ProtectRequest) (*pb.ProtectResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.ProtectResponse{}
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) Unprotect(ctx context.Context, in *pb.UnprotectRequest) (*pb.UnprotectResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.UnprotectResponse{}
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) StorePSK(ctx context.Context, in *pb.StorePSKRequest) (*pb.StorePSKResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.StorePSKResponse{}
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) AddProposal(ctx context.Context, in *pb.AddProposalRequest) (*pb.ProposalResponse, error) {
-	return nil, nil // TODO
+	if string(in.KeyPackage) != "keyPackage" {
+		return nil, status.Error(codes.InvalidArgument, "Invalid key package")
+	}
+
+	resp := &pb.ProposalResponse{
+		Proposal: []byte("addProposal"),
+	}
+
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) UpdateProposal(ctx context.Context, in *pb.UpdateProposalRequest) (*pb.ProposalResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.ProposalResponse{}
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) RemoveProposal(ctx context.Context, in *pb.RemoveProposalRequest) (*pb.ProposalResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.ProposalResponse{}
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) PSKProposal(ctx context.Context, in *pb.PSKProposalRequest) (*pb.ProposalResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.ProposalResponse{}
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) ReInitProposal(ctx context.Context, in *pb.ReInitProposalRequest) (*pb.ProposalResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.ProposalResponse{}
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) AppAckProposal(ctx context.Context, in *pb.AppAckProposalRequest) (*pb.ProposalResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.ProposalResponse{}
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) Commit(ctx context.Context, in *pb.CommitRequest) (*pb.CommitResponse, error) {
-	return nil, nil // TODO
+	resp := &pb.CommitResponse{
+		Commit:  []byte("commit"),
+		Welcome: []byte("welcome"),
+	}
+
+	return resp, nil // TODO
 }
 
 func (mc *MockClient) HandleCommit(ctx context.Context, in *pb.HandleCommitRequest) (*pb.HandleCommitResponse, error) {
-	return nil, nil // TODO
+	if string(in.Commit) != "commit" {
+		return nil, status.Error(codes.InvalidArgument, "Invalid commit")
+	}
+
+	resp := &pb.HandleCommitResponse{}
+	return resp, nil // TODO
 }
 
 ///

--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -238,9 +238,8 @@ message CommitRequest {
 }
 
 message CommitResponse {
-  repeated bytes proposal = 1;
-  bytes commit = 2;
-  bytes welcome = 3;
+  bytes commit = 1;
+  bytes welcome = 2;
 }
 
 // rpc HandleCommit

--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -240,6 +240,7 @@ message CommitRequest {
 message CommitResponse {
   repeated bytes proposal = 1;
   bytes commit = 2;
+  bytes welcome = 3;
 }
 
 // rpc HandleCommit

--- a/interop/rust-mock-client/src/main.rs
+++ b/interop/rust-mock-client/src/main.rs
@@ -131,13 +131,28 @@ impl MlsClient for MlsClientImpl {
         &self,
         _request: tonic::Request<CreateKeyPackageRequest>,
     ) -> Result<tonic::Response<CreateKeyPackageResponse>, tonic::Status> {
-        Ok(Response::new(CreateKeyPackageResponse::default())) // TODO
+        let resp = CreateKeyPackageResponse{ 
+            transaction_id: 0,
+            key_package: String::from("keyPackage").into_bytes(),
+        };
+
+        Ok(Response::new(resp)) // TODO
     }
 
     async fn join_group(
         &self,
-        _request: tonic::Request<JoinGroupRequest>,
+        request: tonic::Request<JoinGroupRequest>,
     ) -> Result<tonic::Response<JoinGroupResponse>, tonic::Status> {
+        let obj = request.get_ref();
+        let welcome = String::from("welcome");
+        let welcome_in = String::from_utf8(obj.welcome.clone()).unwrap();
+        if (welcome != welcome_in) {
+            return Err(tonic::Status::new(
+                tonic::Code::InvalidArgument,
+                "Invalid welcome",
+            ));
+        }
+
         Ok(Response::new(JoinGroupResponse::default())) // TODO
     }
 
@@ -159,7 +174,11 @@ impl MlsClient for MlsClientImpl {
         &self,
         _request: tonic::Request<StateAuthRequest>,
     ) -> Result<tonic::Response<StateAuthResponse>, tonic::Status> {
-        Ok(Response::new(StateAuthResponse::default())) // TODO
+        let resp = StateAuthResponse{ 
+            state_auth_secret: String::from("stateAuthSecret").into_bytes(),
+        };
+
+        Ok(Response::new(resp)) // TODO
     }
 
     async fn export(
@@ -192,9 +211,23 @@ impl MlsClient for MlsClientImpl {
 
     async fn add_proposal(
         &self,
-        _request: tonic::Request<AddProposalRequest>,
+        request: tonic::Request<AddProposalRequest>,
     ) -> Result<tonic::Response<ProposalResponse>, tonic::Status> {
-        Ok(Response::new(ProposalResponse::default())) // TODO
+        let obj = request.get_ref();
+        let key_package = String::from("keyPackage");
+        let key_package_in = String::from_utf8(obj.key_package.clone()).unwrap();
+        if (key_package != key_package_in) {
+            return Err(tonic::Status::new(
+                tonic::Code::InvalidArgument,
+                "Invalid key package",
+            ));
+        }
+
+        let resp = ProposalResponse{ 
+            proposal: String::from("addProposal").into_bytes(),
+        };
+
+        Ok(Response::new(resp)) // TODO
     }
 
     async fn update_proposal(
@@ -236,13 +269,28 @@ impl MlsClient for MlsClientImpl {
         &self,
         _request: tonic::Request<CommitRequest>,
     ) -> Result<tonic::Response<CommitResponse>, tonic::Status> {
-        Ok(Response::new(CommitResponse::default())) // TODO
+        let resp = CommitResponse{ 
+            commit: String::from("commit").into_bytes(),
+            welcome: String::from("welcome").into_bytes(),
+        };
+
+        Ok(Response::new(resp)) // TODO
     }
 
     async fn handle_commit(
         &self,
-        _request: tonic::Request<HandleCommitRequest>,
+        request: tonic::Request<HandleCommitRequest>,
     ) -> Result<tonic::Response<HandleCommitResponse>, tonic::Status> {
+        let obj = request.get_ref();
+        let commit = String::from("commit");
+        let commit_in = String::from_utf8(obj.commit.clone()).unwrap();
+        if (commit != commit_in) {
+            return Err(tonic::Status::new(
+                tonic::Code::InvalidArgument,
+                "Invalid commit",
+            ));
+        }
+
         Ok(Response::new(HandleCommitResponse::default())) // TODO
     }
 }


### PR DESCRIPTION
This PR implements a facility for specifying interop test scenarios, which are then run across all combinations of:

* Assignments of MLS client stacks to actors in the scenario
* Ciphersuites
* Handshake encrypted / not

A basic two-member join scenario is provided in `config.json` and there required actions are implemented in the test runner and the clients.  This scenario works with the test clients, and also with the [corresponding branch of `mlspp`](https://github.com/cisco/mlspp/pull/178).