### PR TITLE
Update treekem test-vectors

### DIFF
--- a/test-vectors.md
+++ b/test-vectors.md
@@ -268,6 +268,7 @@ Format:
   "add_sender": /* uint32 */,
   "my_key_package": /* hex-encoded binary data */,
   "my_path_secret": /* hex-encoded binary data */,
+  "my_leaf_secret": /* hex-encoded binary data */,
 
   "update_sender": /* uint32 */,
   "update_path": /* hex-encoded binary data */,
@@ -280,6 +281,9 @@ Format:
   "tree_hash_after": /* hex-encoded binary data */
 }
 ```
+
+* An empty group context is used
+* The exclusion list in the update path is empty
 
 Some of the binary fields contain TLS-serialized objects:
 * `ratchet_tree_before` and `ratchet_tree_after` contain serialized ratchet
@@ -294,6 +298,7 @@ Verification:
 * Identify the test participant's location in the tree using `my_key_package`
 * Initialize the private state of the tree by setting `my_path_secret` at the
   common ancestor between the test participant's leaf and `add_sender`
+  and `my_leaf_secret` for the leaf
 * Verify that the root secret for the initial tree matches `root_secret_after_add`
 * Process the `update_path` to get a new root secret and update the tree
 * Verify that the new root root secret matches `root_secret_after_update`

--- a/test-vectors.md
+++ b/test-vectors.md
@@ -266,12 +266,13 @@ Format:
   "ratchet_tree_before": /* hex-encoded binary data */,
   
   "add_sender": /* uint32 */,
+  "my_leaf_secret": /* hex-encoded binary data */,
   "my_key_package": /* hex-encoded binary data */,
   "my_path_secret": /* hex-encoded binary data */,
-  "my_leaf_secret": /* hex-encoded binary data */,
 
   "update_sender": /* uint32 */,
   "update_path": /* hex-encoded binary data */,
+  "update_group_context": /* hex-encoded binary data */,
 
   // Computed values
   "tree_hash_before": /* hex-encoded binary data */,
@@ -282,14 +283,12 @@ Format:
 }
 ```
 
-* An empty group context is used
-* The exclusion list in the update path is empty
-
 Some of the binary fields contain TLS-serialized objects:
 * `ratchet_tree_before` and `ratchet_tree_after` contain serialized ratchet
   trees, as in [the `ratchet_tree` extension](https://tools.ietf.org/html/draft-ietf-mls-protocol-11#section-11.3)
 * `my_key_package` contains a KeyPackage object
 * `update_path` contains an UpdatePath object
+* The exclusion list in the update path is empty.
 
 Verification:
 * Verify that the tree hash of `tree_before` equals `tree_hash_before`


### PR DESCRIPTION
Thanks to @kkohbrok we finished the treekem test vector in OpenMLS but had to change it slightly. It's on this [branch](https://github.com/openmls/openmls/tree/franziskus/kat-tree-kem).

* We need the leaf secret because in some cases the path secret is not enough (in case the two nodes are siblings).
* We added the group context to not always use an empty one.
* I clarified that the exclusion list (list of new leaves) is empty.

@bifurcation what do you think?