### PR TITLE
Use handleExternalCommit instead of handleCommit

### DIFF
--- a/interop/config.json
+++ b/interop/config.json
@@ -26,7 +26,7 @@
       {"action": "createGroup", "actor": "alice"},
       {"action": "publicGroupState", "actor": "alice"},
       {"action": "externalJoin", "actor": "bob", "publicGroupState": 1},
-      {"action": "handleCommit", "actor": "alice", "commit": 2},
+      {"action": "handleExternalCommit", "actor": "alice", "commit": 2},
       {"action": "verifyStateAuth"}
     ],
     "stateProperties": [


### PR DESCRIPTION
External commits need to be handled differently from commits.  For example, they cannot be encrypted, even if other commits are.  The current external join test script uses `handleCommit` where it should use `handleExternalCommit`.