### PR TITLE
Extended test vectors with negative test cases

### DIFF
--- a/test-vectors.md
+++ b/test-vectors.md
@@ -334,7 +334,15 @@ Verification:
 * Verify that the tree now matches `tree_after`
 * `error` codes:
   * 1 := ParentHashMissing
-  * 2 := InvalidParentHash
+  * 2 := InvalidKeyPackageSignature
+  * 3 := InvalidCiphersuite
+  * 4 := MissingCapabilitiesExtension
+  * 5 := InvalidCapabilitiesExtension
+  * 6 := MissingLifeTimeExtension
+  * 7 := BeforeLifeTime
+  * 8 := AfterLifeTime
+  * 9 := InvalidParentHash
+  * 16 := InvalidWelcomeKey
 
 Among other things, this test vector ensure the following spec requirements
 
@@ -343,6 +351,17 @@ Among other things, this test vector ensure the following spec requirements
 > [about parent hash] To this end, when processing a Commit message clients MUST recompute the expected value of parent_hash for the committer's new leaf and verify that it matches the parent_hash value in the supplied leaf_key_package.
 
 > [about parent hash] Moreover, when joining a group, new members MUST authenticate each non-blank parent node P.
+
+> A KeyPackage object with an invalid signature field MUST be considered malformed.
+
+> KeyPackage objects MUST contain at least two extensions, [...]
+
+> [about capabilities] This extension MUST be always present in a KeyPackage. Extensions that appear in the extensions field of a KeyPackage MUST be included in the extensions field of the capabilities extension.
+
+> [about lifetime] A client MUST NOT use the data in a KeyPackage for any processing before the not_before date, or after the not_after date
+
+> [about the welcome message] The private key MUST be the private key that corresponds to the public key in the node.
+
 
 ## Messages
 

--- a/test-vectors.md
+++ b/test-vectors.md
@@ -80,6 +80,9 @@ Format:
 
 ```text
 {
+  "result": /* "valid" or "invalid" */,
+  "error": /* uint16 */,
+
   "cipher_suite": /* uint16 */,
   "n_leaves": /* uint32 */,
   "encryption_secret": /* hex-encoded binary data */,
@@ -137,12 +140,32 @@ For all `N` entries in the `leaves` and all generations `j`
   `j`.
 * `sender_data_info.secret.key = sender_data_key(sender_data_secret, sender_data_info.ciphertext)`
 * `sender_data_info.secret.nonce = sender_data_nonce(sender_data_secret, sender_data_info.ciphertext)`
+* `error` codes:
+  * 1 := MembershipTagMissing
+  * 2 := UnexpectedMembershipTag
+  * 3 := InvalidSenderData
+  * 9 := ConfirmationTagMissing
+  * 10 := UnexpectedConfirmationTag
+  * 14 := MissingPath
+  * 15 := InvalidPath
 
 The extra factor of 2 in `2*N` ensures that only chains rooted at leaf nodes are
 tested.  The definitions of `ratchet_key` and `ratchet_nonce` are in the
 [Encryption
 Keys](https://github.com/mlswg/mls-protocol/blob/master/draft-ietf-mls-protocol.md#encryption-keys)
 section of the specification.
+
+Among other things, this test vector ensure the following spec requirements
+
+> The membership_tag field in the MLSPlaintext object authenticates the sender's membership in the group. For an MLSPlaintext with a sender type other than member, this field MUST be omitted. For messages sent by members, it MUST be present
+
+> The field confirmation_tag MUST be present if content_type equals commit. Otherwise, it MUST NOT be present.
+
+> When parsing a SenderData struct as part of message decryption, the recipient MUST verify that the sender field represents an occupied leaf in the ratchet tree. In particular, the sender index value MUST be less than the number of leaves in the tree.
+
+> The path field of a Commit message MUST be populated if the Commit covers at least one Update or Remove proposal. The path field MUST also be populated if the Commit covers no proposals at all (i.e., if the proposals vector is empty).
+
+> If the path field is required based on the proposals that are in the commit (see above), then it MUST be populated.
 
 ## Key Schedule
 
@@ -264,6 +287,9 @@ Parameters:
 Format:
 ```text
 {
+  "result": /* "valid" or "invalid" */,
+  "error": /* uint16 */,
+
   "cipher_suite": /* uint16 */,
 
   // Chosen by the generator
@@ -306,6 +332,17 @@ Verification:
 * Process the `update_path` to get a new root secret and update the tree
 * Verify that the new root root secret matches `root_secret_after_update`
 * Verify that the tree now matches `tree_after`
+* `error` codes:
+  * 1 := ParentHashMissing
+  * 2 := InvalidParentHash
+
+Among other things, this test vector ensure the following spec requirements
+
+> [about parent hash] In particular, the extension MUST be present in the leaf_key_package field of an UpdatePath object.
+
+> [about parent hash] To this end, when processing a Commit message clients MUST recompute the expected value of parent_hash for the committer's new leaf and verify that it matches the parent_hash value in the supplied leaf_key_package.
+
+> [about parent hash] Moreover, when joining a group, new members MUST authenticate each non-blank parent node P.
 
 ## Messages
 
@@ -315,6 +352,9 @@ Parameters:
 Format:
 ```
 {
+  "result": /* "valid" or "invalid" */,
+  "error": /* uint16 */,
+
   "key_package": /* serialized KeyPackage */,
   "capabilities": /* serialized Capabilities */,
   "lifetime": /* serialized {uint64 not_before; uint64 not_after;} */,
@@ -349,7 +389,48 @@ Verification:
 * The contents of each field must decode using the corresponding structure
 * Each decoded object must re-encode to produce the bytes in the test vector
 * The signature on each message must be valid
+  * The signature scheme used must be the one specified in the `KeyPackage` credential of the sender's leaf
+* The key package must have a valid signature
+* `error` codes:
+  * 1 := InvalidMLSPlaintextSignature
+  * 2 := InvalidKeyPackageSignature
+  * 3 := InvalidCiphersuite
+  * 4 := MissingCapabilitiesExtension
+  * 5 := InvalidCapabilitiesExtension
+  * 6 := MissingLifeTimeExtension
+  * 7 := BeforeLifeTime
+  * 8 := AfterLifeTime
+  * 9 := ConfirmationTagMissing
+  * 10 := UnexpectedConfirmationTag
+  * 11 := PSKMissing
+  * 12 := MultiplePSK
+  * 13 := InvalidPSK
+  * 14 := MissingPath
+  * 15 := InvalidPath
+  * 16 := InvalidWelcomeKey
 
 The specific contents of the objects are chosen by the creator of the test
 vectors.  The objects produced must be syntactically valid. The optional MAC
 values may be invalid but should be populated.
+
+Among other things, this test vector ensure the following spec requirements
+
+> The signature algorithm specified in the ciphersuite is the mandatory algorithm to be used for signatures in MLSPlaintext and the tree signatures. It MUST be the same as the signature algorithm specified in the credential field of the KeyPackage objects in the leaves of the tree (including the InitKeys used to add new members).
+
+> A KeyPackage object with an invalid signature field MUST be considered malformed.
+
+> KeyPackage objects MUST contain at least two extensions, [...]
+
+> [about capabilities] This extension MUST be always present in a KeyPackage. Extensions that appear in the extensions field of a KeyPackage MUST be included in the extensions field of the capabilities extension.
+
+> [about lifetime] A client MUST NOT use the data in a KeyPackage for any processing before the not_before date, or after the not_after date
+
+> The field confirmation_tag MUST be present if content_type equals commit. Otherwise, it MUST NOT be present.
+
+> The Welcome message MUST specify exactly one pre-shared key with psktype = reinit, and with psk_group_id and psk_epoch equal to the group_id and epoch of the existing group after the Commit containing the reinit Proposal was processed.
+
+> The path field of a Commit message MUST be populated if the Commit covers at least one Update or Remove proposal. The path field MUST also be populated if the Commit covers no proposals at all (i.e., if the proposals vector is empty).
+
+> If the path field is required based on the proposals that are in the commit (see above), then it MUST be populated.
+
+> [about the welcome message] The private key MUST be the private key that corresponds to the public key in the node.

--- a/test-vectors.md
+++ b/test-vectors.md
@@ -291,6 +291,7 @@ Format:
   "error": /* uint16 */,
 
   "cipher_suite": /* uint16 */,
+  "date": /* uint64 */,
 
   // Chosen by the generator
   "ratchet_tree_before": /* hex-encoded binary data */,
@@ -373,6 +374,7 @@ Format:
 {
   "result": /* "valid" or "invalid" */,
   "error": /* uint16 */,
+  "date": /* uint64 */,
 
   "key_package": /* serialized KeyPackage */,
   "capabilities": /* serialized Capabilities */,


### PR DESCRIPTION
This PR extends the test vectors to test more MUST (NOT) requirements from the spec.
It also introduces negative test cases. When the `result` of a test vector is `"invalid"`, the `error` must match.

Thanks @TWal for collecting all the cases from the spec.

cc @kkohbrok, @eiqo 