### PR TITLE
Increase timeout

### DIFF
--- a/interop/test-runner/main.go
+++ b/interop/test-runner/main.go
@@ -157,7 +157,7 @@ type Client struct {
 }
 
 func ctx() context.Context {
-	c, _ := context.WithTimeout(context.Background(), time.Second)
+	c, _ := context.WithTimeout(context.Background(), time.Second * 10)
 	return c
 }
 


### PR DESCRIPTION
Increase the timeout for clients to respond to test runner queries.