### PR TITLE
make psk_secret an array in key_schedule kat

### DIFF
--- a/test-vectors.md
+++ b/test-vectors.md
@@ -165,8 +165,11 @@ Format:
       // Chosen by the generator
       "tree_hash": /* hex-encoded binary data */,
       "commit_secret": /* hex-encoded binary data */,
-      "psk_secrets": [
-        /* hex-encoded binary data */,
+      "psks": [
+        {
+          psk: /* hex-encoded binary data */,
+          psk_id: /* hex encoded PreSharedKeyID */
+        },
         ...
       ],
       "confirmed_transcript_hash": /* hex-encoded binary data */,
@@ -212,6 +215,7 @@ Verification:
     inputs:
     * `init_key` from the prior epoch or `initial_init_secret`
     * `commit_secret` and `psk_secret` as specified
+      * The `psk_secret` is computed from the `psks` [as defined in the specification](https://github.com/mlswg/mls-protocol/blob/main/draft-ietf-mls-protocol.md#pre-shared-keys)
     * `GroupContext_[n]` as computed above
 
 ## Commits and Transcript Hashes

--- a/test-vectors.md
+++ b/test-vectors.md
@@ -165,7 +165,10 @@ Format:
       // Chosen by the generator
       "tree_hash": /* hex-encoded binary data */,
       "commit_secret": /* hex-encoded binary data */,
-      "psk_secret": /* hex-encoded binary data */,
+      "psk_secrets": [
+        /* hex-encoded binary data */,
+        ...
+      ],
       "confirmed_transcript_hash": /* hex-encoded binary data */,
       
       // Computed values


### PR DESCRIPTION
The change in https://github.com/mlswg/mls-protocol/pull/490 is not noticeable with this test vector because only a single PSK is being used.
The KAT should instead take an array of PSKs.

- [x] make this PSKs, not psk_secret