### PR TITLE
Update list of implementations

### DIFF
--- a/implementation_list.md
+++ b/implementation_list.md
@@ -2,7 +2,8 @@
 
  - `mlspp` (C++) [https://github.com/cisco/mlspp](https://github.com/cisco/mlspp) (Status: draft-17 in progress)
  - `OpenMLS` (Rust) [https://github.com/openmls/openmls](https://github.com/openmls/openmls) (Status: draft-17 in progress)
- - [Wickr](https://wickr.com/) proprietary implementation (Rust) (Status: draft-17 in progress)
+ - [Wickr](https://wickr.com/) (Rust) proprietary implementation (Status: draft-17 in progress)
+ - `MLS*` (F*) (Status: draft-16)
 
 ## Older / out of date links
 

--- a/implementation_list.md
+++ b/implementation_list.md
@@ -1,11 +1,15 @@
 # List of existing MLS implementations
 
- - `mlspp` (C++) [https://github.com/cisco/mlspp](https://github.com/cisco/mlspp) (Status: draft-11 in progress)
- - `OpenMLS` (Rust) [https://github.com/openmls/openmls](https://github.com/openmls/openmls) (Status: draft-11 in progress)
- - `go-mls` (Go) [https://github.com/cisco/go-mls](https://github.com/cisco/go-mls) (Status: roughly draft-09)
- - `mls-ts` (TypeScript) [ https://gitlab.matrix.org/matrix-org/mls-ts]( https://gitlab.matrix.org/matrix-org/mls-ts) (Status: PoC)
+ - `mlspp` (C++) [https://github.com/cisco/mlspp](https://github.com/cisco/mlspp) (Status: draft-17 in progress)
+ - `OpenMLS` (Rust) [https://github.com/openmls/openmls](https://github.com/openmls/openmls) (Status: draft-17 in progress)
+ - [Wickr](https://wickr.com/) proprietary implementation (Rust) (Status: draft-17 in progress)
 
 ## Older / out of date links
+
+### Earlier MLS implementations
+
+ - `go-mls` (Go) [https://github.com/cisco/go-mls](https://github.com/cisco/go-mls) (Status: roughly draft-09)
+ - `mls-ts` (TypeScript) [ https://gitlab.matrix.org/matrix-org/mls-ts]( https://gitlab.matrix.org/matrix-org/mls-ts) (Status: PoC)
 
 ### TreeKEM implementations
 


### PR DESCRIPTION
Moves a couple of abandoned ones below the line, and adds the Wickr implementation.

@TWal should we add an entry here for your implementation?  Doesn't matter if you have a public repo, just trying to document what exists.