### PR TITLE
State that test vector files are an array

### DIFF
--- a/test-vectors.md
+++ b/test-vectors.md
@@ -33,9 +33,12 @@ the syntax of the messages used for MLS (independent of semantics).
 
 ### Representation
 
-Test vectors are JSON serialized.  `optional<type>` is serialized as the value
-itself or `null` if not present.  MLS structs are binary encoded according to
-spec and represented as hex-encoded strings in JSON.
+* Test vectors are JSON serialized.
+* Each test vector file is an array of objects in the form described here.
+* `optional<type>` is serialized as the value itself or `null` if not present.
+* MLS structs are binary encoded according to spec and represented as
+  hex-encoded strings in JSON.
+
 
 ## Tree Math
 
@@ -45,17 +48,15 @@ Parameters:
 Format:
 
 ```
-[
-  {
-    "n_leaves": /* uint32 */,
-    "n_nodes": /* uint32 */,
-    "root": /* uint32 */,
-    "left": [ /* array of optional<uint32> */ ],
-    "right": [ /* array of optional<uint32> */ ],
-    "parent": [ /* array of optional<uint32> */ ],
-    "sibling": [ /* array of optional<uint32> */ ]
-  }
-]
+{
+  "n_leaves": /* uint32 */,
+  "n_nodes": /* uint32 */,
+  "root": /* uint32 */,
+  "left": [ /* array of optional<uint32> */ ],
+  "right": [ /* array of optional<uint32> */ ],
+  "parent": [ /* array of optional<uint32> */ ],
+  "sibling": [ /* array of optional<uint32> */ ]
+}
 ```
 
 Verification:


### PR DESCRIPTION
This way we don't have to show each example as an array.  The only one for which the array framing doesn't really make sense is the messages test vector, which doesn't depend on the ciphersuite.  We can either special-case that or just make it a one-element array.