### PR TITLE
Add `confirmation_tag` in Message Protection description

### DIFF
--- a/test-vectors.md
+++ b/test-vectors.md
@@ -230,6 +230,7 @@ Format:
   "encryption_secret": /* hex-encoded binary data */,
   "sender_data_secret": /* hex-encoded binary data */,
   "membership_key": /* hex-encoded binary data */,
+  "confirmation_tag": /* hex-encoded binary data */,
 
   "proposal":  /* serialized Proposal */,
   "proposal_pub":  /* serialized MLSMessage(PublicMessage) */,


### PR DESCRIPTION
It is present is the JSON but missing in the description