### PR TITLE
Remove test vector functions from gRPC interface

### DIFF
--- a/interop/config.json
+++ b/interop/config.json
@@ -2,14 +2,6 @@
   "clients": [
     "localhost:50003"
   ],
-  "test_vectors": [
-    "tree_math",
-    "encryption",
-    "key_schedule",
-    "transcript",
-    "treekem",
-    "messages"
-  ],
   "scripts": {
         "two_party": [
           {"action": "createGroup", "actor": "alice"},

--- a/interop/cpp-mock-client/mock_client.cpp
+++ b/interop/cpp-mock-client/mock_client.cpp
@@ -56,101 +56,6 @@ class MLSClientImpl final : public MLSClient::Service
     return Status::OK;
   }
 
-  Status GenerateTestVector(ServerContext* /* context */,
-                            const GenerateTestVectorRequest* request,
-                            GenerateTestVectorResponse* reply) override
-  {
-    std::cout << "Got GenerateTestVector request: ";
-    switch (request->test_vector_type()) {
-      case TestVectorType::TREE_MATH: {
-        std::cout << "Tree math" << std::endl;
-        break;
-      }
-
-      case TestVectorType::ENCRYPTION: {
-        std::cout << "Encryption" << std::endl;
-        break;
-      }
-
-      case TestVectorType::KEY_SCHEDULE: {
-        std::cout << "Key schedule" << std::endl;
-        break;
-      }
-
-      case TestVectorType::TRANSCRIPT: {
-        std::cout << "Transcript" << std::endl;
-        break;
-      }
-
-      case TestVectorType::TREEKEM: {
-        std::cout << "TreeKEM" << std::endl;
-        break;
-      }
-
-      case TestVectorType::MESSAGES: {
-        std::cout << "Messages" << std::endl;
-        break;
-      }
-
-      default: {
-        std::cout << "Invalid" << std::endl;
-        return Status(StatusCode::INVALID_ARGUMENT, "Invalid test vector type");
-      }
-    }
-
-    reply->set_test_vector(fixed_test_vector);
-    return Status::OK;
-  }
-
-  Status VerifyTestVector(ServerContext* /* context */,
-                          const VerifyTestVectorRequest* request,
-                          VerifyTestVectorResponse* /* reply */) override
-  {
-    std::cout << "Got VerifyTestVector request: ";
-    switch (request->test_vector_type()) {
-      case TestVectorType::TREE_MATH: {
-        std::cout << "Tree math" << std::endl;
-        break;
-      }
-
-      case TestVectorType::ENCRYPTION: {
-        std::cout << "Encryption" << std::endl;
-        break;
-      }
-
-      case TestVectorType::KEY_SCHEDULE: {
-        std::cout << "Key schedule" << std::endl;
-        break;
-      }
-
-      case TestVectorType::TRANSCRIPT: {
-        std::cout << "Transcript" << std::endl;
-        break;
-      }
-
-      case TestVectorType::TREEKEM: {
-        std::cout << "TreeKEM" << std::endl;
-        break;
-      }
-
-      case TestVectorType::MESSAGES: {
-        std::cout << "Messages" << std::endl;
-        break;
-      }
-
-      default: {
-        std::cout << "Invalid" << std::endl;
-        return Status(StatusCode::INVALID_ARGUMENT, "Invalid test vector type");
-      }
-    }
-
-    if (request->test_vector() != fixed_test_vector) {
-      return Status(StatusCode::INVALID_ARGUMENT, "Invalid test vector");
-    }
-
-    return Status::OK;
-  }
-
   // Ways to become a member of a group
   Status CreateGroup(ServerContext* /* context */,
                      const CreateGroupRequest* /* request */,
@@ -301,13 +206,6 @@ class MLSClientImpl final : public MLSClient::Service
 
   Status ReInitProposal(ServerContext* /* context */,
                         const ReInitProposalRequest* /* request */,
-                        ProposalResponse* /* response */) override
-  {
-    return Status::OK; // TODO
-  }
-
-  Status AppAckProposal(ServerContext* /* context */,
-                        const AppAckProposalRequest* /* request */,
                         ProposalResponse* /* response */) override
   {
     return Status::OK; // TODO

--- a/interop/go-mock-client/main.go
+++ b/interop/go-mock-client/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -28,9 +27,9 @@ func newID(universe map[uint32]bool) uint32 {
 	return id
 }
 
-///
-/// Mock client implementation
-///
+// /
+// / Mock client implementation
+// /
 type MockClient struct {
 	pb.MLSClientServer
 	transactions map[uint32]bool
@@ -52,68 +51,6 @@ func (mc *MockClient) Name(ctx context.Context, req *pb.NameRequest) (*pb.NameRe
 func (mc *MockClient) SupportedCiphersuites(ctx context.Context, req *pb.SupportedCiphersuitesRequest) (*pb.SupportedCiphersuitesResponse, error) {
 	log.Printf("Received SupportedCiphersuites request")
 	return &pb.SupportedCiphersuitesResponse{Ciphersuites: supportedCiphersuites}, nil
-}
-
-func (mc *MockClient) GenerateTestVector(ctx context.Context, req *pb.GenerateTestVectorRequest) (*pb.GenerateTestVectorResponse, error) {
-	log.Printf("Received GenerateTestVector request")
-
-	switch req.TestVectorType {
-	case pb.TestVectorType_TREE_MATH:
-		log.Printf("Tree math test vector request")
-
-	case pb.TestVectorType_ENCRYPTION:
-		log.Printf("Encryption test vector request")
-
-	case pb.TestVectorType_KEY_SCHEDULE:
-		log.Printf("Key schedule test vector request")
-
-	case pb.TestVectorType_TRANSCRIPT:
-		log.Printf("Transcript test vector request")
-
-	case pb.TestVectorType_TREEKEM:
-		log.Printf("TreeKEM test vector request")
-
-	case pb.TestVectorType_MESSAGES:
-		log.Printf("Messages test vector request")
-
-	default:
-		return nil, status.Error(codes.InvalidArgument, "Invalid test vector type")
-	}
-
-	return &pb.GenerateTestVectorResponse{TestVector: testVector}, nil
-}
-
-func (mc *MockClient) VerifyTestVector(ctx context.Context, req *pb.VerifyTestVectorRequest) (*pb.VerifyTestVectorResponse, error) {
-	log.Printf("Received VerifyTestVector request")
-
-	switch req.TestVectorType {
-	case pb.TestVectorType_TREE_MATH:
-		log.Printf("Tree math test vector request")
-
-	case pb.TestVectorType_ENCRYPTION:
-		log.Printf("Encryption test vector request")
-
-	case pb.TestVectorType_KEY_SCHEDULE:
-		log.Printf("Key schedule test vector request")
-
-	case pb.TestVectorType_TRANSCRIPT:
-		log.Printf("Transcript test vector request")
-
-	case pb.TestVectorType_TREEKEM:
-		log.Printf("TreeKEM test vector request")
-
-	case pb.TestVectorType_MESSAGES:
-		log.Printf("Messages test vector request")
-
-	default:
-		return nil, status.Error(codes.InvalidArgument, "Invalid test vector type")
-	}
-
-	if !bytes.Equal(req.TestVector, testVector) {
-		return nil, status.Error(codes.InvalidArgument, "Invalid test vector")
-	}
-
-	return &pb.VerifyTestVectorResponse{}, nil
 }
 
 // Ways to become a member of a group
@@ -260,11 +197,6 @@ func (mc *MockClient) PSKProposal(ctx context.Context, in *pb.PSKProposalRequest
 }
 
 func (mc *MockClient) ReInitProposal(ctx context.Context, in *pb.ReInitProposalRequest) (*pb.ProposalResponse, error) {
-	resp := &pb.ProposalResponse{}
-	return resp, nil // TODO
-}
-
-func (mc *MockClient) AppAckProposal(ctx context.Context, in *pb.AppAckProposalRequest) (*pb.ProposalResponse, error) {
 	resp := &pb.ProposalResponse{}
 	return resp, nil // TODO
 }

--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -12,10 +12,6 @@ service MLSClient {
   // List of supported ciphersuites
   rpc SupportedCiphersuites(SupportedCiphersuitesRequest) returns (SupportedCiphersuitesResponse) {}
 
-  // Test vector generation and verification
-  rpc GenerateTestVector(GenerateTestVectorRequest) returns (GenerateTestVectorResponse) {}
-  rpc VerifyTestVector(VerifyTestVectorRequest) returns (VerifyTestVectorResponse) {}
-
   // Ways to become a member of a group
   rpc CreateGroup(CreateGroupRequest) returns (CreateGroupResponse) {}
   rpc CreateKeyPackage(CreateKeyPackageRequest) returns (CreateKeyPackageResponse) {}
@@ -55,38 +51,6 @@ message SupportedCiphersuitesRequest {}
 message SupportedCiphersuitesResponse {
   repeated uint32 ciphersuites = 1; // Actually uint16 ciphersuite values
 }
-
-// rpc GenerateTestVector
-enum TestVectorType {
-  TREE_MATH = 0;
-  ENCRYPTION = 1;
-  KEY_SCHEDULE = 2;
-  TRANSCRIPT = 3;
-  TREEKEM = 4;
-  MESSAGES = 5;
-}
-
-// Generation parameters that are not needed for a given test type are ignored
-message GenerateTestVectorRequest {
-  TestVectorType test_vector_type = 1;
-  uint32 cipher_suite = 2; // Actually uint16
-  uint32 n_leaves = 3;
-  uint32 n_generations = 4;
-  uint32 n_epochs = 5;
-}
-
-message GenerateTestVectorResponse {
-  bytes test_vector = 1;
-}
-
-// rpc VerifyTestVector
-message VerifyTestVectorRequest {
-  TestVectorType test_vector_type = 1;
-  bytes test_vector = 2;
-}
-
-message VerifyTestVectorResponse {}
-
 
 // rpc CreateGroup
 // XXX(RLB): Credential type is omitted; let's just use Basic for these tests

--- a/interop/rust-mock-client/src/main.rs
+++ b/interop/rust-mock-client/src/main.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use std::convert::TryFrom;
 use std::net::IpAddr;
 use tonic::{transport::Server, Request, Response, Status};
 
@@ -13,23 +12,6 @@ pub mod mls_client {
 
 const IMPLEMENTATION_NAME: &str = "Mock-Rust";
 const SUPPORTED_CIPHERSUITES: [u32; 2] = [0xA0A0, 0xA1A1];
-const TEST_VECTOR: [u8; 4] = [0, 1, 2, 3];
-
-impl TryFrom<i32> for TestVectorType {
-    type Error = ();
-
-    fn try_from(value: i32) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(TestVectorType::TreeMath),
-            1 => Ok(TestVectorType::Encryption),
-            2 => Ok(TestVectorType::KeySchedule),
-            3 => Ok(TestVectorType::Transcript),
-            4 => Ok(TestVectorType::Treekem),
-            5 => Ok(TestVectorType::Messages),
-            _ => Err(()),
-        }
-    }
-}
 
 #[derive(Default)]
 pub struct MlsClientImpl {}
@@ -76,69 +58,6 @@ impl MlsClient for MlsClientImpl {
         };
 
         Ok(Response::new(response))
-    }
-
-    async fn generate_test_vector(
-        &self,
-        request: tonic::Request<GenerateTestVectorRequest>,
-    ) -> Result<tonic::Response<GenerateTestVectorResponse>, tonic::Status> {
-        println!("Got GenerateTestVector request");
-
-        let obj = request.get_ref();
-        let type_msg = match TestVectorType::try_from(obj.test_vector_type) {
-            Ok(TestVectorType::TreeMath) => "Tree math",
-            Ok(TestVectorType::Encryption) => "Encryption",
-            Ok(TestVectorType::KeySchedule) => "Key Schedule",
-            Ok(TestVectorType::Transcript) => "Transcript",
-            Ok(TestVectorType::Treekem) => "TreeKEM",
-            Ok(TestVectorType::Messages) => "Messages",
-            Err(_) => {
-                return Err(tonic::Status::new(
-                    tonic::Code::InvalidArgument,
-                    "Invalid test vector type",
-                ));
-            }
-        };
-        println!("{} test vector request", type_msg);
-
-        let response = GenerateTestVectorResponse {
-            test_vector: TEST_VECTOR.to_vec(),
-        };
-
-        Ok(Response::new(response))
-    }
-
-    async fn verify_test_vector(
-        &self,
-        request: tonic::Request<VerifyTestVectorRequest>,
-    ) -> Result<tonic::Response<VerifyTestVectorResponse>, tonic::Status> {
-        println!("Got VerifyTestVector request");
-
-        let obj = request.get_ref();
-        let type_msg = match TestVectorType::try_from(obj.test_vector_type) {
-            Ok(TestVectorType::TreeMath) => "Tree math",
-            Ok(TestVectorType::Encryption) => "Encryption",
-            Ok(TestVectorType::KeySchedule) => "Key Schedule",
-            Ok(TestVectorType::Transcript) => "Transcript",
-            Ok(TestVectorType::Treekem) => "TreeKEM",
-            Ok(TestVectorType::Messages) => "Messages",
-            Err(_) => {
-                return Err(tonic::Status::new(
-                    tonic::Code::InvalidArgument,
-                    "Invalid test vector type",
-                ));
-            }
-        };
-        println!("{} test vector request", type_msg);
-
-        if obj.test_vector != TEST_VECTOR {
-            return Err(tonic::Status::new(
-                tonic::Code::InvalidArgument,
-                "Invalid test vector",
-            ));
-        }
-
-        Ok(Response::new(VerifyTestVectorResponse::default()))
     }
 
     async fn create_group(


### PR DESCRIPTION
Instead of manually passing test vectors from one stack to another via gRPC, we have focused more recently on developing a single suite of test vectors for the protocol.  This PR removes the test vector generate/verify RPCs from the gRPC interface and strips the relevant code from the mock clients and test runner.