### PR TITLE
Make gRPC test runner less thorough to allow more actors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "cmake.sourceDirectory": "${workspaceFolder}/interop/cpp-mock-client"
-}

--- a/interop/config.json
+++ b/interop/config.json
@@ -4,6 +4,7 @@
     "localhost:50002",
     "localhost:50003"
   ],
+  "run_for_all_combinations": false,
   "scripts": {
         "two_party": [
           {"action": "createGroup", "actor": "alice"},

--- a/interop/config.json
+++ b/interop/config.json
@@ -1,5 +1,7 @@
 {
   "clients": [
+    "localhost:50001",
+    "localhost:50002",
     "localhost:50003"
   ],
   "scripts": {
@@ -18,7 +20,14 @@
           {"action": "handleCommit", "actor": "charlie", "commit": 10},
           {"action": "handlePendingCommit", "actor": "alice"},
           {"action": "protect", "actor": "alice", "applicationData": "aGVsbG8="},
-          {"action": "unprotect", "actor": "charlie", "ciphertext": 13}
+          {"action": "unprotect", "actor": "charlie", "ciphertext": 13},
+          {"action": "createKeyPackage", "actor": "1bob"},
+          {"action": "createKeyPackage", "actor": "2bob"},
+          {"action": "createKeyPackage", "actor": "3bob"},
+          {"action": "addProposal", "actor": "alice", "keyPackage": 15},
+          {"action": "addProposal", "actor": "alice", "keyPackage": 16},
+          {"action": "addProposal", "actor": "alice", "keyPackage": 17},
+          {"action": "commit", "actor": "alice", "byReference": []}
         ]
   }
 }

--- a/interop/test-runner/main.go
+++ b/interop/test-runner/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"strconv"
 	"time"
@@ -876,21 +877,25 @@ func (p *ClientPool) ScriptMatrix(actors []string) []ScriptActorConfig {
 
 	configs := make([]ScriptActorConfig, 0, configSize)
 	for suite, clients := range p.suiteSupport {
-		for _, combo := range combinations(len(clients), len(actors)) {
-			for _, encrypt := range []bool{true, false} {
-				config := ScriptActorConfig{
-					CipherSuite:      suite,
-					EncryptHandshake: encrypt,
-					ActorClients:     map[string]*Client{},
-				}
-
-				for i := range actors {
-					config.ActorClients[actors[i]] = p.clients[combo[i]]
-				}
-
-				configs = append(configs, config)
+		for _, encrypt := range []bool{true, false} {
+			config := ScriptActorConfig{
+				CipherSuite:      suite,
+				EncryptHandshake: encrypt,
+				ActorClients:     map[string]*Client{},
 			}
+
+			seed := rand.Int63()
+			fmt.Println("Preparing script matrix with random seed", seed)
+			rand.Seed(seed)
+			combo := rand.Perm(len(actors))
+
+			for i := range actors {
+				config.ActorClients[actors[combo[i]]] = p.clients[clients[i%len(clients)]]
+			}
+
+			configs = append(configs, config)
 		}
+
 	}
 
 	return configs


### PR DESCRIPTION
Currently, the number of permutations grows exponentially with the number of actors. The new function creates a single random permutation of evenly spread clients. We can run the test many times to get many permutations.