### PR TITLE
Clean up Commit RPCs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	google.golang.org/grpc v1.36.0
-	google.golang.org/protobuf v1.25.0
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 // indirect
+	google.golang.org/protobuf v1.28.1
 )

--- a/interop/config.json
+++ b/interop/config.json
@@ -1,6 +1,6 @@
 {
   "clients": [
-    "localhost:50003"
+    "localhost:5000"
   ],
   "scripts": {
         "two_party": [
@@ -9,7 +9,7 @@
           {"action": "addProposal", "actor": "alice", "keyPackage": 1},
           {"action": "createKeyPackage", "actor": "charlie"},
           {"action": "addProposal", "actor": "alice", "keyPackage": 3},
-          {"action": "commit", "actor": "alice", "byReference": []},
+          {"action": "commit", "actor": "alice", "byReference": [2, 4]},
           {"action": "joinGroup", "actor": "bob", "welcome": 5},
           {"action": "joinGroup", "actor": "charlie", "welcome": 5},
           {"action": "handlePendingCommit", "actor": "alice"},

--- a/interop/cpp-mock-client/mock_client.cpp
+++ b/interop/cpp-mock-client/mock_client.cpp
@@ -221,6 +221,7 @@ class MLSClientImpl final : public MLSClient::Service
 
     response->set_commit("commit");
     response->set_welcome("welcome");
+    response->set_epoch_authenticator("epoch_authenticator");
     return Status::OK;
   }
 
@@ -237,22 +238,20 @@ class MLSClientImpl final : public MLSClient::Service
     }
 
     response->set_state_id(newID(states));
+    response->set_epoch_authenticator("epoch_authenticator");
     return Status::OK;
   }
 
-  Status HandleExternalCommit(ServerContext* /* context */,
-                              const HandleExternalCommitRequest* request,
-                              HandleExternalCommitResponse* response) override
+  Status HandlePendingCommit(ServerContext* /* context */,
+                      const HandlePendingCommitRequest* request,
+                      HandleCommitResponse* response) override
   {
     if (states.count(request->state_id()) == 0) {
       return Status(StatusCode::INVALID_ARGUMENT, "Invalid state");
     }
 
-    if (request->commit() != "commit") {
-      return Status(StatusCode::INVALID_ARGUMENT, "Invalid commit");
-    }
-
     response->set_state_id(newID(states));
+    response->set_epoch_authenticator("epoch_authenticator");
     return Status::OK;
   }
 };

--- a/interop/go-mock-client/main.go
+++ b/interop/go-mock-client/main.go
@@ -208,8 +208,9 @@ func (mc *MockClient) Commit(ctx context.Context, in *pb.CommitRequest) (*pb.Com
 	}
 
 	resp := &pb.CommitResponse{
-		Commit:  []byte("commit"),
-		Welcome: []byte("welcome"),
+		Commit:             []byte("commit"),
+		Welcome:            []byte("welcome"),
+		EpochAuthenticator: []byte("epoch_authenticator"),
 	}
 
 	return resp, nil
@@ -226,25 +227,23 @@ func (mc *MockClient) HandleCommit(ctx context.Context, in *pb.HandleCommitReque
 	}
 
 	resp := &pb.HandleCommitResponse{
-		StateId: newID(mc.states),
+		StateId:            newID(mc.states),
+		EpochAuthenticator: []byte("epoch_authenticator"),
 	}
 
 	mc.states[resp.StateId] = true
 	return resp, nil
 }
 
-func (mc *MockClient) HandleExternalCommit(ctx context.Context, in *pb.HandleExternalCommitRequest) (*pb.HandleExternalCommitResponse, error) {
+func (mc *MockClient) HandlePendingCommit(ctx context.Context, in *pb.HandlePendingCommitRequest) (*pb.HandleCommitResponse, error) {
 	if !mc.states[in.StateId] {
 		fmt.Printf("Invalid state (handle): %d\n", in.StateId)
 		return nil, status.Error(codes.InvalidArgument, "Invalid state")
 	}
 
-	if string(in.Commit) != "commit" {
-		return nil, status.Error(codes.InvalidArgument, "Invalid commit")
-	}
-
-	resp := &pb.HandleExternalCommitResponse{
-		StateId: newID(mc.states),
+	resp := &pb.HandleCommitResponse{
+		StateId:            newID(mc.states),
+		EpochAuthenticator: []byte("epoch_authenticator"),
 	}
 
 	mc.states[resp.StateId] = true

--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -35,7 +35,6 @@ service MLSClient {
   rpc Commit(CommitRequest) returns (CommitResponse) {}
   rpc HandleCommit(HandleCommitRequest) returns (HandleCommitResponse) {}
   rpc HandlePendingCommit(HandlePendingCommitRequest) returns (HandleCommitResponse) {}
-  rpc HandleExternalCommit(HandleExternalCommitRequest) returns (HandleExternalCommitResponse) {}
 }
 
 // rpc Name
@@ -199,6 +198,7 @@ message CommitRequest {
 message CommitResponse {
   bytes commit = 1;
   bytes welcome = 2;
+  bytes epoch_authenticator = 3;
 }
 
 // rpc HandleCommit
@@ -210,24 +210,10 @@ message HandleCommitRequest {
 
 message HandleCommitResponse { 
   uint32 state_id = 1;
-  repeated uint32 added = 2;
-  repeated uint32 removed_indices = 3;
-  repeated bytes removed_leaves = 4;
-  repeated uint32 updated = 5;
-  repeated bytes psks = 6;
+  bytes epoch_authenticator = 2;
 }
 
 // rpc HandlePendingCommit
 message HandlePendingCommitRequest {
-  uint32 state_id = 1;
-}
-
-// rpc HandleExternalCommit
-message HandleExternalCommitRequest {
-  uint32 state_id = 1;
-  bytes commit = 3;
-}
-
-message HandleExternalCommitResponse { 
   uint32 state_id = 1;
 }

--- a/interop/rust-mock-client/src/main.rs
+++ b/interop/rust-mock-client/src/main.rs
@@ -306,6 +306,7 @@ impl MlsClient for MlsClientImpl {
         let resp = CommitResponse {
             commit: String::from("commit").into_bytes(),
             welcome: String::from("welcome").into_bytes(),
+            epoch_authenticator: String::from("epoch_authenticator").into_bytes(),
         };
 
         Ok(Response::new(resp)) // TODO
@@ -335,11 +336,7 @@ impl MlsClient for MlsClientImpl {
 
         let resp = HandleCommitResponse {
             state_id: self.new_state_id(),
-            added: vec![0, 1, 2],
-            removed_indices: vec![0, 1],
-            removed_leaves: vec![vec![0u8; 10], vec![1u8; 16]],
-            updated: vec![],
-            psks: vec![],
+            epoch_authenticator: String::from("epoch_authenticator").into_bytes(),
         };
 
         Ok(Response::new(resp)) // TODO
@@ -359,40 +356,7 @@ impl MlsClient for MlsClientImpl {
 
         let resp = HandleCommitResponse {
             state_id: self.new_state_id(),
-            added: vec![0, 1, 2],
-            removed_indices: vec![0, 1],
-            removed_leaves: vec![vec![0u8; 10], vec![1u8; 16]],
-            updated: vec![],
-            psks: vec![],
-        };
-
-        Ok(Response::new(resp)) // TODO
-    }
-
-    async fn handle_external_commit(
-        &self,
-        request: tonic::Request<HandleExternalCommitRequest>,
-    ) -> Result<tonic::Response<HandleExternalCommitResponse>, tonic::Status> {
-        let obj = request.get_ref();
-        if !self.known_state_id(obj.state_id) {
-            return Err(tonic::Status::new(
-                tonic::Code::InvalidArgument,
-                "Invalid state ID",
-            ));
-        }
-
-        let obj = request.get_ref();
-        let commit = String::from("commit");
-        let commit_in = String::from_utf8(obj.commit.clone()).unwrap();
-        if commit != commit_in {
-            return Err(tonic::Status::new(
-                tonic::Code::InvalidArgument,
-                "Invalid commit",
-            ));
-        }
-
-        let resp = HandleExternalCommitResponse {
-            state_id: self.new_state_id(),
+            epoch_authenticator: String::from("epoch_authenticator").into_bytes(),
         };
 
         Ok(Response::new(resp)) // TODO

--- a/interop/test-runner/main.go
+++ b/interop/test-runner/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -23,22 +24,21 @@ import (
 type ScriptAction string
 
 const (
-	ActionCreateGroup          ScriptAction = "createGroup"
-	ActionCreateKeyPackage     ScriptAction = "createKeyPackage"
-	ActionJoinGroup            ScriptAction = "joinGroup"
-	ActionExternalJoin         ScriptAction = "externalJoin"
-	ActionPublicGroupState     ScriptAction = "publicGroupState"
-	ActionAddProposal          ScriptAction = "addProposal"
-	ActionUpdateProposal       ScriptAction = "updateProposal"
-	ActionRemoveProposal       ScriptAction = "removeProposal"
-	ActionCommit               ScriptAction = "commit"
-	ActionHandleCommit         ScriptAction = "handleCommit"
-	ActionHandlePendingCommit  ScriptAction = "handlePendingCommit"
-	ActionHandleExternalCommit ScriptAction = "handleExternalCommit"
-	ActionVerifyStateAuth      ScriptAction = "verifyStateAuth"
-	ActionStateProperties      ScriptAction = "stateProperties"
-	ActionProtect              ScriptAction = "protect"
-	ActionUnprotect            ScriptAction = "unprotect"
+	ActionCreateGroup         ScriptAction = "createGroup"
+	ActionCreateKeyPackage    ScriptAction = "createKeyPackage"
+	ActionJoinGroup           ScriptAction = "joinGroup"
+	ActionExternalJoin        ScriptAction = "externalJoin"
+	ActionPublicGroupState    ScriptAction = "publicGroupState"
+	ActionAddProposal         ScriptAction = "addProposal"
+	ActionUpdateProposal      ScriptAction = "updateProposal"
+	ActionRemoveProposal      ScriptAction = "removeProposal"
+	ActionCommit              ScriptAction = "commit"
+	ActionHandleCommit        ScriptAction = "handleCommit"
+	ActionHandlePendingCommit ScriptAction = "handlePendingCommit"
+	ActionVerifyStateAuth     ScriptAction = "verifyStateAuth"
+	ActionStateProperties     ScriptAction = "stateProperties"
+	ActionProtect             ScriptAction = "protect"
+	ActionUnprotect           ScriptAction = "unprotect"
 
 	ScriptStateProperties = "stateProperties"
 	ActorLeader           = "leader"
@@ -490,6 +490,7 @@ func (config *ScriptActorConfig) RunStep(index int, step ScriptStep) error {
 
 		config.StoreMessage(index, "commit", resp.Commit)
 		config.StoreMessage(index, "welcome", resp.Welcome)
+		config.StoreMessage(index, "epoch_authenticator", resp.EpochAuthenticator)
 
 	case ActionProtect:
 		client := config.ActorClients[step.Actor]
@@ -567,21 +568,13 @@ func (config *ScriptActorConfig) RunStep(index int, step ScriptStep) error {
 
 		config.stateID[step.Actor] = resp.StateId
 
-		for i, leafIndex := range resp.Added {
-			config.StoreInteger(index, fmt.Sprintf("added %d", i), leafIndex)
+		epochAuthenticator, err := config.GetMessage(params.Commit, "epoch_authenticator")
+		if err != nil {
+			return err
 		}
 
-		for i, leafIndex := range resp.Updated {
-			config.StoreInteger(index, fmt.Sprintf("updated %d", i), leafIndex)
-		}
-
-		if len(resp.RemovedIndices) != len(resp.RemovedLeaves) {
-			return fmt.Errorf("Lengths of removed leaves (%d) and indices(%d) do not match.", len(resp.RemovedLeaves), len(resp.RemovedIndices))
-		}
-
-		for i := 0; i < len(resp.RemovedIndices); i++ {
-			config.StoreInteger(index, fmt.Sprintf("removedIndex %d", i), resp.RemovedIndices[i])
-			config.StoreMessage(index, fmt.Sprintf("removedLeaf %d", i), resp.RemovedLeaves[i])
+		if !bytes.Equal(resp.EpochAuthenticator, epochAuthenticator) {
+			return fmt.Errorf("Epoch authenticator mismatch")
 		}
 
 	case ActionHandlePendingCommit:
@@ -593,55 +586,6 @@ func (config *ScriptActorConfig) RunStep(index int, step ScriptStep) error {
 
 		resp, err := client.rpc.HandlePendingCommit(ctx(), req)
 
-		if err != nil {
-			return err
-		}
-
-		config.stateID[step.Actor] = resp.StateId
-
-		for i, leafIndex := range resp.Added {
-			config.StoreInteger(index, fmt.Sprintf("added %d", i), leafIndex)
-		}
-
-		for i, leafIndex := range resp.Updated {
-			config.StoreInteger(index, fmt.Sprintf("updated %d", i), leafIndex)
-		}
-
-		if len(resp.RemovedIndices) != len(resp.RemovedLeaves) {
-			return fmt.Errorf("Lengths of removed leaves (%d) and indices(%d) do not match.", len(resp.RemovedLeaves), len(resp.RemovedIndices))
-		}
-
-		for i := 0; i < len(resp.RemovedIndices); i++ {
-			config.StoreInteger(index, fmt.Sprintf("removedIndex %d", i), resp.RemovedIndices[i])
-			config.StoreMessage(index, fmt.Sprintf("removedLeaf %d", i), resp.RemovedLeaves[i])
-		}
-
-	case ActionHandleExternalCommit:
-		client := config.ActorClients[step.Actor]
-		var params HandleCommitStepParams
-		err := json.Unmarshal(step.Raw, &params)
-		if err != nil {
-			return err
-		}
-
-		commit, err := config.GetMessage(params.Commit, "commit")
-		if err != nil {
-			return err
-		}
-
-		byRef := make([][]byte, len(params.ByReference))
-		for i, ix64 := range params.ByReference {
-			byRef[i], err = config.GetMessage(int(ix64), "proposal")
-			if err != nil {
-				return err
-			}
-		}
-
-		req := &pb.HandleExternalCommitRequest{
-			StateId: config.stateID[step.Actor],
-			Commit:  commit,
-		}
-		resp, err := client.rpc.HandleExternalCommit(ctx(), req)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR makes a few changes to the Commit RPCs:

* Removes the `HandleExternalCommit` RPC, since all the known stacks use the same API as for normal commits
* Removes the details from `CommitResponse` and `HandleCommitResponse`, since they were unused
* Adds  an `epoch_authenticator` field to `CommitResponse` and `HandleCommitResponse` so that the test runner can quickly check agreement without an extra RPC.

And then implements it in the three mock clients.