### PR TITLE
Update test runner config to be more usable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,5 @@ go 1.16
 
 require (
 	google.golang.org/grpc v1.36.0
-	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 // indirect
 	google.golang.org/protobuf v1.28.1
 )

--- a/interop/config.json
+++ b/interop/config.json
@@ -1,7 +1,4 @@
 {
-  "clients": [
-    "localhost:5000"
-  ],
   "scripts": {
         "two_party": [
           {"action": "createGroup", "actor": "alice"},
@@ -15,7 +12,7 @@
           {"action": "handlePendingCommit", "actor": "alice"},
           {"action": "removeProposal", "actor": "charlie", "removed": "bob"},
           {"action": "commit", "actor": "alice", "byReference": [9]},
-          {"action": "handleCommit", "actor": "charlie", "commit": 10},
+          {"action": "handleCommit", "actor": "charlie", "commit": 10, "byReference": [9]},
           {"action": "handlePendingCommit", "actor": "alice"},
           {"action": "protect", "actor": "alice", "applicationData": "aGVsbG8="},
           {"action": "unprotect", "actor": "charlie", "ciphertext": 13}

--- a/interop/test-runner/main.go
+++ b/interop/test-runner/main.go
@@ -130,7 +130,6 @@ func (s Script) Actors() []string {
 }
 
 type RunConfig struct {
-	Clients []string          `json:"clients"`
 	Scripts map[string]Script `json:"scripts",omitempty`
 }
 
@@ -897,11 +896,25 @@ func (p *ClientPool) RunScript(name string, script Script) ScriptResults {
 // /
 // / Main logic
 // /
+
+type stringListFlag []string
+
+func (i *stringListFlag) String() string {
+	return "repeated options"
+}
+
+func (i *stringListFlag) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
 var (
-	configOpt string
+	clientsOpt stringListFlag
+	configOpt  string
 )
 
 func init() {
+	flag.Var(&clientsOpt, "client", "host:port for a client")
 	flag.StringVar(&configOpt, "config", "config.json", "config file name")
 	flag.Parse()
 }
@@ -931,7 +944,8 @@ func main() {
 	chk("Failure to parse config file", err)
 
 	// Connect to clients
-	clientPool, err := NewClientPool(config.Clients)
+	fmt.Println("clients", clientsOpt)
+	clientPool, err := NewClientPool(clientsOpt)
 	chk("Failure to conenct to clients", err)
 	defer clientPool.Close()
 


### PR DESCRIPTION
This PR updates how the test runnier is configured to be more usable:

* Instead of configuring clients in `config.json`, they are provided as command-line options
* A new `-random` option is provided that causes a random selection of clients to be used
* A new `-suite` option is provided that causes tests to only be run for a single ciphersuite
* New `-public` and `-private` options are provided that cause tests to be run with only PublicMessage/PrivateMessage

This should enable us to have more durable `config.json` files that capture different sets of interop tests, and then run those scenarios against various collections of clients.