### PR TITLE
Add epoch authenticator to JoinGroupResponse

### DIFF
--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -85,6 +85,7 @@ message JoinGroupRequest {
 
 message JoinGroupResponse { 
   uint32 state_id = 1;
+  bytes epoch_authenticator = 2;
 }
 
 // rpc ExternalJoin

--- a/interop/test-runner/main.go
+++ b/interop/test-runner/main.go
@@ -372,6 +372,15 @@ func (config *ScriptActorConfig) RunStep(index int, step ScriptStep) error {
 			return err
 		}
 
+		epochAuthenticator, err := config.GetMessage(params.Welcome, "epoch_authenticator")
+		if err != nil {
+			return err
+		}
+
+		if !bytes.Equal(resp.EpochAuthenticator, epochAuthenticator) {
+			return fmt.Errorf("Epoch authenticator mismatch %x != %x", resp.EpochAuthenticator, epochAuthenticator)
+		}
+
 		config.stateID[step.Actor] = resp.StateId
 
 	case ActionExternalJoin:
@@ -594,7 +603,7 @@ func (config *ScriptActorConfig) RunStep(index int, step ScriptStep) error {
 		}
 
 		if !bytes.Equal(resp.EpochAuthenticator, epochAuthenticator) {
-			return fmt.Errorf("Epoch authenticator mismatch")
+			return fmt.Errorf("Epoch authenticator mismatch %x != %x", resp.EpochAuthenticator, epochAuthenticator)
 		}
 
 	case ActionHandlePendingCommit:


### PR DESCRIPTION
... and check it in the test runner when processing the response.  This ensures that the new joiner is in the same state as the committer after the Commit/Welcome.