### PR TITLE
Add a 'fullCommit' action

### DIFF
--- a/interop/config.json
+++ b/interop/config.json
@@ -6,16 +6,11 @@
           {"action": "addProposal", "actor": "alice", "keyPackage": 1},
           {"action": "createKeyPackage", "actor": "charlie"},
           {"action": "addProposal", "actor": "alice", "keyPackage": 3},
-          {"action": "commit", "actor": "alice", "byReference": [2, 4]},
-          {"action": "joinGroup", "actor": "bob", "welcome": 5},
-          {"action": "joinGroup", "actor": "charlie", "welcome": 5},
-          {"action": "handlePendingCommit", "actor": "alice"},
+          {"action": "fullCommit", "actor": "alice", "byReference": [2, 4], "joiners": ["bob", "charlie"]},
           {"action": "removeProposal", "actor": "charlie", "removed": "bob"},
-          {"action": "commit", "actor": "alice", "byReference": [9]},
-          {"action": "handleCommit", "actor": "charlie", "commit": 10, "byReference": [9]},
-          {"action": "handlePendingCommit", "actor": "alice"},
+          {"action": "fullCommit", "actor": "alice", "byReference": [6], "members": ["charlie"]},
           {"action": "protect", "actor": "alice", "applicationData": "aGVsbG8="},
-          {"action": "unprotect", "actor": "charlie", "ciphertext": 13}
+          {"action": "unprotect", "actor": "charlie", "ciphertext": 8}
         ]
   }
 }

--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -85,6 +85,7 @@ message JoinGroupRequest {
 
 message JoinGroupResponse { 
   uint32 state_id = 1;
+  bytes epoch_authenticator = 2;
 }
 
 // rpc ExternalJoin
@@ -202,7 +203,6 @@ message CommitRequest {
 message CommitResponse {
   bytes commit = 1;
   bytes welcome = 2;
-  bytes epoch_authenticator = 3;
 }
 
 // rpc HandleCommit


### PR DESCRIPTION
This PR adds a `fullCommit` action to the test runner, which combines the `commit`, `handlePendingCommit`, `handleCommit`, and `joinGroup`.  The motivation here was to remove the need for `CommitResponse.EpochAuthenticator`, which could be challenging for stacks to produce if they haven't moved into the new state.  Just removing would introduce some ambiguity about how to verify that all the member agree on the epoch authenticator; the approach here keeps the epoch authenticator as local state across the individual steps.

Combining these steps also makes the scripts more terse, of course.

Note that with this, the only reason to keep `handleCommit` is to be able to test the case where a member creates a commit, but then another commit gets applied.  We could probably safely delete the individual `handlePendingCommit`, `handleCommit`, and `joinGroup` actions, since these aren't required for this disaggregated case.