### PR TITLE
Join-by-Welcome active tests and supporting API/logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	google.golang.org/grpc v1.36.0
-	google.golang.org/protobuf v1.28.1
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 // indirect
+	google.golang.org/protobuf v1.29.0
 )

--- a/interop/configs/welcome_join.json
+++ b/interop/configs/welcome_join.json
@@ -1,0 +1,33 @@
+{
+  "scripts": {
+    "no_path_secret": [
+          {"action": "createGroup", "actor": "alice"},
+          {"action": "createKeyPackage", "actor": "bob"},
+          {"action": "addProposal", "actor": "alice", "keyPackage": 1},
+          {"action": "fullCommit", "actor": "alice", "byReference": [2], "joiners": ["bob"]}
+    ],
+
+    "with_path_secret": [
+          {"action": "createGroup", "actor": "alice"},
+          {"action": "createKeyPackage", "actor": "bob"},
+          {"action": "addProposal", "actor": "alice", "keyPackage": 1},
+          {"action": "fullCommit", "actor": "alice", "byReference": [2], "joiners": ["bob"], "force_path": true}
+    ],
+
+    "with_psk": [
+          {"action": "createGroup", "actor": "alice"},
+          {"action": "createKeyPackage", "actor": "bob"},
+          {"action": "addProposal", "actor": "alice", "keyPackage": 1},
+          {"action": "installExternalPSK", "clients": ["alice", "bob"]},
+          {"action": "preSharedKeyProposal", "actor": "alice", "psk": 3},
+          {"action": "fullCommit", "actor": "alice", "byReference": [2, 4], "joiners": ["bob"]}
+    ],
+
+    "with_external_tree": [
+          {"action": "createGroup", "actor": "alice"},
+          {"action": "createKeyPackage", "actor": "bob"},
+          {"action": "addProposal", "actor": "alice", "keyPackage": 1},
+          {"action": "fullCommit", "actor": "alice", "byReference": [2], "joiners": ["bob"], "external_tree": true}
+    ]
+  }
+}

--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -198,6 +198,7 @@ message ReInitProposalRequest {
 }
 
 // rpc Commit
+// Note: CommitResponse.ratchet_tree should be empty if CommitRequest.external_tree is not true
 message CommitRequest {
   uint32 state_id = 1;
   repeated bytes by_reference = 2;

--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -84,6 +84,7 @@ message JoinGroupRequest {
   bytes welcome = 2;
   bool encrypt_handshake = 3;
   bytes identity = 4;
+  bytes ratchet_tree = 5;
 }
 
 message JoinGroupResponse { 
@@ -155,9 +156,9 @@ message UnprotectResponse {
 
 // rpc StorePSK
 message StorePSKRequest {
-  uint32 state_id = 1;
+  uint32 state_or_transaction_id = 1;
   bytes psk_id = 2;
-  bytes psk = 3;
+  bytes psk_secret = 3;
 }
 
 message StorePSKResponse {}
@@ -201,11 +202,14 @@ message CommitRequest {
   uint32 state_id = 1;
   repeated bytes by_reference = 2;
   repeated bytes by_value = 3;
+  bool force_path = 4;
+  bool external_tree = 5;
 }
 
 message CommitResponse {
   bytes commit = 1;
   bytes welcome = 2;
+  bytes ratchet_tree = 3;
 }
 
 // rpc HandleCommit


### PR DESCRIPTION
This PR adds a config file `welcome_join.json` that covers join-by-welcome cases.  It also adds some gRPC mechanism that is necessary to generate the required cases:

* Adding `force_path` and `external_tree` fields to CommitRequest, and a `ratchet_tree` field on CommitResponse
* Adding an `installExternalPSK` action that generates a PSK and installs it on clients
* Updating the active-to-passive script to capture PSKs and external trees

I have verified that this works with [my working branch of MLSpp](https://github.com/cisco/mlspp/tree/welcome-config), in the sense that (a) MLSpp interoperates with itself via gRPC, and (b) the generated passive test vector passes.

Depends on #128, should probably not be reviewed until that is merged and this PR is rebased.