### PR TITLE
Add application data protection tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mlswg/mls-implementations
 go 1.16
 
 require (
+	github.com/google/uuid v1.1.2
 	google.golang.org/grpc v1.36.0
-	google.golang.org/protobuf v1.29.1 // indirect
+	google.golang.org/protobuf v1.29.1
 )

--- a/interop/configs/application.json
+++ b/interop/configs/application.json
@@ -1,0 +1,47 @@
+{
+  "scripts": {
+    "in_order": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw1", "plaintext": "hello world 1"},
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw2", "plaintext": "hello world 2"},
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw3", "plaintext": "hello world 3"},
+
+      {"action": "unprotect", "actor": "bob", "ciphertext": 2 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 3 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 4 }
+    ],
+
+    "out_of_order_within_epoch": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw1", "plaintext": "hello world 1"},
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw2", "plaintext": "hello world 2"},
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw3", "plaintext": "hello world 3"},
+
+      {"action": "unprotect", "actor": "bob", "ciphertext": 4 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 3 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 2 }
+    ],
+
+    "out_of_order_across_epochs": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw1", "plaintext": "hello world 1"},
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw2", "plaintext": "hello world 2"},
+
+      {"action": "fullCommit", "actor": "alice", "members": ["bob"]},
+
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw3", "plaintext": "hello world 3"},
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw4", "plaintext": "hello world 4"},
+
+      {"action": "unprotect", "actor": "bob", "ciphertext": 6 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 5 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 3 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 2 }
+    ]
+  }
+}

--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -150,7 +150,8 @@ message ExportResponse {
 // rpc Protect
 message ProtectRequest {
   uint32 state_id = 1;
-  bytes application_data = 2;
+  bytes authenticated_data = 2;
+  bytes plaintext = 3;
 }
 
 message ProtectResponse { 
@@ -164,7 +165,8 @@ message UnprotectRequest {
 }
 
 message UnprotectResponse {
-  bytes application_data = 1;
+  bytes authenticated_data = 1;
+  bytes plaintext = 2;
 }
 
 // rpc StorePSK

--- a/interop/test-runner/main.go
+++ b/interop/test-runner/main.go
@@ -124,8 +124,8 @@ type HandleCommitStepParams struct {
 }
 
 type ProtectStepParams struct {
-	AuthenticatedData []byte `json:"authenticatedData"`
-	Plaintext         []byte `json:"applicationData"`
+	AuthenticatedData string `json:"authenticatedData"`
+	Plaintext         string `json:"plaintext"`
 }
 
 type UnprotectStepParams struct {
@@ -858,18 +858,20 @@ func (config *ScriptActorConfig) RunStep(index int, step ScriptStep) error {
 			return err
 		}
 
+		authenticatedData := []byte(params.AuthenticatedData)
+		plaintext := []byte(params.Plaintext)
 		req := &pb.ProtectRequest{
 			StateId:           config.stateID[step.Actor],
-			AuthenticatedData: params.AuthenticatedData,
-			Plaintext:         params.Plaintext,
+			AuthenticatedData: authenticatedData,
+			Plaintext:         plaintext,
 		}
 		resp, err := client.rpc.Protect(ctx(), req)
 		if err != nil {
 			return err
 		}
 
-		config.StoreMessage(index, "authenticatedData", params.AuthenticatedData)
-		config.StoreMessage(index, "plaintext", params.Plaintext)
+		config.StoreMessage(index, "authenticatedData", authenticatedData)
+		config.StoreMessage(index, "plaintext", plaintext)
 		config.StoreMessage(index, "ciphertext", resp.Ciphertext)
 
 	case ActionUnprotect:

--- a/interop/test-runner/main.go
+++ b/interop/test-runner/main.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	"google.golang.org/grpc"
 
 	pb "github.com/mlswg/mls-implementations/interop/proto"
@@ -362,7 +363,7 @@ func (config *ScriptActorConfig) RunStep(index int, step ScriptStep) error {
 	case ActionCreateGroup:
 		client := config.ActorClients[step.Actor]
 		req := &pb.CreateGroupRequest{
-			GroupId:          []byte("group"),
+			GroupId:          []byte(uuid.New().String()),
 			CipherSuite:      config.CipherSuite,
 			EncryptHandshake: config.EncryptHandshake,
 			Identity:         []byte(step.Actor),


### PR DESCRIPTION
Tests three scenarios:

* Unprotect in the same order as protect
* Out-of-order unprotect within an epoch
* Out-of-order unprotect across epochs

Also, updates the RPCs to exercise `MLSCiphertext.authenticated_data`.