### PR TITLE
Support Reinit in gRPC-based tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.16
 require (
 	github.com/google/uuid v1.1.2
 	google.golang.org/grpc v1.36.0
-	google.golang.org/protobuf v1.29.1
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 // indirect
+	google.golang.org/protobuf v1.30.0
 )

--- a/interop/configs/reinit.json
+++ b/interop/configs/reinit.json
@@ -1,0 +1,104 @@
+{
+  "scripts": {
+    "change_ciphersuite": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {
+        "action": "reinit", 
+        "proposer": "alice",
+        "committer": "bob",
+        "welcomer": "charlie", 
+        "members": ["diana", "eliza"],
+        "changeCiphersuite": true
+      }
+    ],
+    
+    "change_group_id": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {
+        "action": "reinit", 
+        "proposer": "alice",
+        "committer": "bob",
+        "welcomer": "charlie", 
+        "members": ["diana", "eliza"],
+        "changeGroupID": true
+      }
+    ],
+    
+    "change_extensions": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {
+        "action": "reinit", 
+        "proposer": "alice",
+        "committer": "bob",
+        "welcomer": "charlie", 
+        "members": ["diana", "eliza"],
+        "extensions": [
+          {"extension_type": 3, "extension_data": "AAAA"},
+          {"extension_type": 5, "extension_data": "AA=="}
+        ]
+      }
+    ],
+    
+    "all_same_actor": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {
+        "action": "reinit", 
+        "proposer": "alice",
+        "committer": "alice",
+        "welcomer": "alice", 
+        "members": ["bob", "charlie", "diana", "eliza"],
+        "changeGroupID": true
+      }
+    ],
+    
+    "external_tree": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {
+        "action": "reinit", 
+        "proposer": "alice",
+        "committer": "bob",
+        "welcomer": "charlie", 
+        "members": ["diana", "eliza"],
+        "changeGroupID": true,
+        "externalTree": true
+      }
+    ],
+    
+    "force_path": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {
+        "action": "reinit", 
+        "proposer": "alice",
+        "committer": "bob",
+        "welcomer": "charlie", 
+        "members": ["diana", "eliza"],
+        "changeGroupID": true,
+        "forcePath": true
+      }
+    ]
+  }
+}

--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -31,12 +31,19 @@ service MLSClient {
   rpc RemoveProposal(RemoveProposalRequest) returns (ProposalResponse) {}
   rpc ExternalPSKProposal(ExternalPSKProposalRequest) returns (ProposalResponse) {}
   rpc ResumptionPSKProposal(ResumptionPSKProposalRequest) returns (ProposalResponse) {}
-  rpc ReInitProposal(ReInitProposalRequest) returns (ProposalResponse) {}
   rpc GroupContextExtensionsProposal(GroupContextExtensionsProposalRequest) returns (ProposalResponse) {}
   
   rpc Commit(CommitRequest) returns (CommitResponse) {}
   rpc HandleCommit(HandleCommitRequest) returns (HandleCommitResponse) {}
   rpc HandlePendingCommit(HandlePendingCommitRequest) returns (HandleCommitResponse) {}
+
+  // Reinitialization
+  rpc ReInitProposal(ReInitProposalRequest) returns (ProposalResponse) {}
+  rpc ReInitCommit(CommitRequest) returns (CommitResponse) {}
+  rpc HandlePendingReInitCommit(HandlePendingCommitRequest) returns (HandleReInitCommitResponse) {}
+  rpc HandleReInitCommit(HandleCommitRequest) returns (HandleReInitCommitResponse) {}
+  rpc ReInitWelcome(ReInitWelcomeRequest) returns (ReInitWelcomeResponse) {}
+  rpc HandleReInitWelcome(HandleReInitWelcomeRequest) returns (JoinGroupResponse) {}
 }
 
 // rpc Name
@@ -211,13 +218,6 @@ message ResumptionPSKProposalRequest {
   uint64 epoch_id = 2;
 }
 
-// rpc ReInitProposal
-message ReInitProposalRequest {
-  uint32 state_id = 1;
-  bytes group_id = 2;
-  uint32 cipher_suite = 3; // actually uint16
-}
-
 // rpc GroupContextExtensionsProposal
 message Extension {
   uint32 extension_type = 1;
@@ -270,3 +270,46 @@ message HandleCommitResponse {
 message HandlePendingCommitRequest {
   uint32 state_id = 1;
 }
+
+// rpc ReInitProposal
+message ReInitProposalRequest {
+  uint32 state_id = 1;
+  uint32 cipher_suite = 2;
+  bytes group_id = 3;
+  repeated Extension extensions = 4;
+}
+
+// rpc ReInitCommit
+// (uses CommitRequest / CommitResponse)
+
+// rpc HandlePendingReInitCommit
+// rpc HandleReInitCommit
+// (uses HandleCommitRequest)
+message HandleReInitCommitResponse {
+  uint32 reinit_id = 1;
+  bytes key_package = 2;
+  bytes epoch_authenticator = 3;
+}
+
+// rpc ReInitWelcome
+message ReInitWelcomeRequest {
+  uint32 reinit_id = 1;
+  repeated bytes key_package = 2;
+  bool force_path = 3;
+  bool external_tree = 4;
+}
+
+message ReInitWelcomeResponse {
+  uint32 state_id = 1;
+  bytes welcome = 2;
+  bytes ratchet_tree = 3;
+  bytes epoch_authenticator = 4;
+}
+
+// rpc HandleReInitWelcome
+message HandleReInitWelcomeRequest {
+  uint32 reinit_id = 1;
+  bytes welcome = 2;
+  bytes ratchet_tree = 3;
+}
+


### PR DESCRIPTION
This PR adds RPCs to do ReInit functions, and a test config to drive it.  Draft for now because I have not implemented the new RPCs or run the scripts (at least the test runner builds, though!).