### PR TITLE
Add support for reinit by external proposals. Add remaining external proposal types to the config.

### DIFF
--- a/interop/configs/external_proposals.json
+++ b/interop/configs/external_proposals.json
@@ -46,6 +46,32 @@
        "description": { "proposalType": "externalPSK", "pskID": 3 } },
       {"action": "fullCommit", "actor": "alice", "byReference": [6], "members": ["bob", "charlie"] }
     ],
+
+    "resumption_psk": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+
+      {"action": "addExternalSigner", "actor": "alice", "signer": "ds"},
+      {"action": "fullCommit", "actor": "alice", "byReference": [3], "members": ["bob", "charlie"]},
+      
+      {"action": "externalSignerProposal", "actor": "ds", "member": "alice",
+       "description": { "proposalType": "resumptionPSK", "epochID": 2 } },
+      {"action": "fullCommit", "actor": "alice", "byReference": [5], "members": ["bob", "charlie"] }
+    ],
+
+    "group_context_extensions": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+
+      {"action": "addExternalSigner", "actor": "alice", "signer": "ds"},
+      {"action": "fullCommit", "actor": "alice", "byReference": [3], "members": ["bob", "charlie"]},
+      
+      {"action": "externalSignerProposal", "actor": "ds", "member": "alice", "description": {
+        "proposalType": "groupContextExtensions", "extensions": [ {"extension_type": 3, "extension_data": "AAAA"} ] } },
+      {"action": "fullCommit", "actor": "alice", "byReference": [5], "members": ["bob", "charlie"] }
+    ],
     
     "multiple_external": [
       {"action": "createGroup", "actor": "alice"},
@@ -65,6 +91,28 @@
       {"action": "externalSignerProposal", "actor": "ds1", "member": "alice",
        "description": { "proposalType": "externalPSK", "pskID": 4 } },
       {"action": "fullCommit", "actor": "alice", "byReference": [9, 10], "members": ["bob", "charlie"] }
+    ],
+
+    "external_reinit": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+
+      {"action": "addExternalSigner", "actor": "alice", "signer": "ds"},
+      {"action": "fullCommit", "actor": "alice", "byReference": [3], "members": ["bob", "charlie"]},
+
+      {"action": "externalSignerProposal", "actor": "ds", "member": "alice",
+       "description": {"proposalType": "reinit", "changeGroupID": true, "changeCipherSuite": true,
+       "extensions": [ {"extension_type": 3, "extension_data": "AAAA"} ]}},
+
+      {
+        "action": "reinit", 
+        "externalReinitProposal": 5,
+        "committer": "alice",
+        "welcomer": "bob", 
+        "members": ["charlie"],
+        "forcePath": true
+      }
     ]
   }
 }

--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -42,11 +42,11 @@ service MLSClient {
   rpc ReInitCommit(CommitRequest) returns (CommitResponse) {}
   rpc HandlePendingReInitCommit(HandlePendingCommitRequest) returns (HandleReInitCommitResponse) {}
   rpc HandleReInitCommit(HandleCommitRequest) returns (HandleReInitCommitResponse) {}
-  rpc ReInitWelcome(ReInitWelcomeRequest) returns (ReInitWelcomeResponse) {}
+  rpc ReInitWelcome(ReInitWelcomeRequest) returns (CreateSubgroupResponse) {}
   rpc HandleReInitWelcome(HandleReInitWelcomeRequest) returns (JoinGroupResponse) {}
 
   // Subgroup Branching
-  rpc CreateBranch(CreateBranchRequest) returns (CreateBranchResponse) {}
+  rpc CreateBranch(CreateBranchRequest) returns (CreateSubgroupResponse) {}
   rpc HandleBranch(HandleBranchRequest) returns (HandleBranchResponse) {}
 
   // External proposals
@@ -239,13 +239,18 @@ message GroupContextExtensionsProposalRequest {
   repeated Extension extensions = 2;
 }
 
+// `proposal_type` is one of "add", "remove", "externalPSK", "resumptionPSK",
+// "groupContextExtensions", "reinit". The type "reinit" can only be used in
+// rpc ExternalSignerProposal.
 message ProposalDescription {
-  bytes proposal_type = 1; // One of "add", "remove", "externalPSK", "resumptionPSK", "groupContextExtensions"
+  bytes proposal_type = 1;
   bytes key_package = 2; // Required if proposal_type is "add"
   bytes removed_id = 3; // Required if proposal_type is "remove"
   bytes psk_id = 4; // Required if proposal_type is "externalPSK"
   uint64 epoch_id = 5; // Required if proposal_type is "resumptionPSK"
-  repeated Extension extensions = 6; // Required if proposal_type is "groupContextExtensions"
+  repeated Extension extensions = 6; // Required if proposal_type is "groupContextExtensions" or "reinit"
+  bytes group_id = 7; // Required if proposal_type is "reinit"
+  uint32 cipher_suite = 8; // Required if proposal_type is "reinit"
 }
 
 // rpc Commit
@@ -309,7 +314,7 @@ message ReInitWelcomeRequest {
   bool external_tree = 4;
 }
 
-message ReInitWelcomeResponse {
+message CreateSubgroupResponse {
   uint32 state_id = 1;
   bytes welcome = 2;
   bytes ratchet_tree = 3;
@@ -325,6 +330,7 @@ message HandleReInitWelcomeRequest {
 
 
 // rpc CreateBranch
+// (uses CreateSubgroupResponse)
 message CreateBranchRequest {
   uint32 state_id = 1;
   bytes group_id = 2;
@@ -332,13 +338,6 @@ message CreateBranchRequest {
   repeated bytes key_packages = 4;
   bool force_path = 5;
   bool external_tree = 6;
-}
-
-message CreateBranchResponse {
-  uint32 state_id = 1;
-  bytes welcome = 2;
-  bytes ratchet_tree = 3;
-  bytes epoch_authenticator = 4;
 }
 
 // rpc CreateBranch

--- a/interop/test-runner/main.go
+++ b/interop/test-runner/main.go
@@ -109,12 +109,14 @@ type GroupContextExtensionsProposalStepParams struct {
 }
 
 type ProposalDescription struct {
-	ProposalType string          `json:"proposalType"`
-	KeyPackage   int             `json:"keyPackage"`
-	Removed      string          `json:"removed"`
-	PskId        int             `json:"pskID"`
-	EpochId      int             `json:"epochID"`
-	Extensions   []*pb.Extension `json:"extensions"`
+	ProposalType      string          `json:"proposalType"`
+	KeyPackage        int             `json:"keyPackage"`
+	Removed           string          `json:"removed"`
+	PskId             int             `json:"pskID"`
+	EpochId           int             `json:"epochID"`
+	Extensions        []*pb.Extension `json:"extensions"`
+	ChangeGroupId     bool            `json:"changeGroupID"`
+	ChangeCipherSuite bool            `json:"changeCipherSuite"`
 }
 
 func (proposalDescription *ProposalDescription) ProposalDescriptionToProto(config *ScriptActorConfig) (*pb.ProposalDescription, error) {
@@ -132,6 +134,17 @@ func (proposalDescription *ProposalDescription) ProposalDescriptionToProto(confi
 		proposalDescProto.EpochId = uint64(proposalDescription.EpochId)
 	case "groupContextExtensions":
 		proposalDescProto.Extensions = proposalDescription.Extensions
+	case "reinit":
+		proposalDescProto.Extensions = proposalDescription.Extensions
+		if proposalDescription.ChangeCipherSuite {
+			err = config.ChangeCipherSuite()
+			if err != nil {
+				return nil, err
+			}
+		}
+		proposalDescProto.CipherSuite = config.CipherSuite
+		proposalDescProto.GroupId, err = config.NewGroupID(proposalDescription.ChangeGroupId)
+
 	default:
 		err = fmt.Errorf("unknown proposal type [%s]", proposalDescription.ProposalType)
 	}
@@ -174,15 +187,16 @@ type UnprotectStepParams struct {
 }
 
 type ReInitStepParams struct {
-	Proposer          string          `json:"proposer"`
-	Committer         string          `json:"committer"`
-	Welcomer          string          `json:"welcomer"`
-	Members           []string        `json:"members"`
-	ChangeCipherSuite bool            `json:"changeCipherSuite"`
-	ChangeGroupID     bool            `json:"changeGroupID"`
-	Extensions        []*pb.Extension `json:"extensions"`
-	ForcePath         bool            `json:"forcePath"`
-	ExternalTree      bool            `json:"externalTree"`
+	Proposer               string          `json:"proposer"`
+	Committer              string          `json:"committer"`
+	Welcomer               string          `json:"welcomer"`
+	Members                []string        `json:"members"`
+	ChangeCipherSuite      bool            `json:"changeCipherSuite"`
+	ChangeGroupID          bool            `json:"changeGroupID"`
+	Extensions             []*pb.Extension `json:"extensions"`
+	ForcePath              bool            `json:"forcePath"`
+	ExternalTree           bool            `json:"externalTree"`
+	ExternalReinitProposal int             `json:"externalReinitProposal"`
 }
 
 type BranchStepParams struct {
@@ -450,6 +464,54 @@ func (config *ScriptActorConfig) GetMessage(index int, key string) ([]byte, erro
 
 func (config *ScriptActorConfig) StoreInteger(index int, key string, integer uint32) {
 	config.transcript[index][key] = strconv.FormatUint(uint64(integer), 10)
+}
+
+func (config *ScriptActorConfig) NewGroupID(changeId bool) ([]byte, error) {
+	newGroupID, err := config.GetMessage(0, "group_id")
+	if err != nil {
+		return nil, err
+	}
+	if changeId {
+		newGroupID = append(newGroupID, []byte("++")...)
+	}
+	return newGroupID, nil
+}
+
+func (config *ScriptActorConfig) ChangeCipherSuite() error {
+	// Compute the set of ciphersuites supported by all clients
+	var supportedSuites map[uint32]bool
+	for _, client := range config.ActorClients {
+		// Initialize with the first client
+		if supportedSuites == nil {
+			supportedSuites = map[uint32]bool{}
+			for suite := range client.supported {
+				supportedSuites[suite] = true
+			}
+			continue
+		}
+
+		// Then remove suites not supported by other clients
+		for suite := range supportedSuites {
+			if !client.supported[suite] {
+				delete(supportedSuites, suite)
+			}
+		}
+	}
+
+	// Remove the current ciphersuite
+	delete(supportedSuites, config.CipherSuite)
+
+	// Select one of the remaining ones
+	if len(supportedSuites) == 0 {
+		return fmt.Errorf("no remaining supported ciphersuite")
+	}
+
+	for suite := range supportedSuites {
+		config.CipherSuite = suite
+		break
+	}
+
+	return nil
 }
 
 func (config *ScriptActorConfig) RunStep(index int, step ScriptStep) error {
@@ -1073,69 +1135,41 @@ func (config *ScriptActorConfig) RunStep(index int, step ScriptStep) error {
 		}
 
 		// Compute sets of members less the committer and the welcomer
-		notCommitter := map[string]bool{params.Proposer: true, params.Welcomer: true}
-		notWelcomer := map[string]bool{params.Proposer: true, params.Committer: true}
+		notCommitter := map[string]bool{params.Welcomer: true}
+		notWelcomer := map[string]bool{params.Committer: true}
 		for _, member := range params.Members {
 			notCommitter[member] = true
 			notWelcomer[member] = true
+		}
+		if params.Proposer != "" {
+			notCommitter[params.Proposer] = true
+			notWelcomer[params.Proposer] = true
 		}
 
 		delete(notCommitter, params.Committer)
 		delete(notWelcomer, params.Welcomer)
 
 		// Decide on the parameters to send
-		newGroupID, err := config.GetMessage(0, "group_id")
+		newGroupID, err := config.NewGroupID(params.ChangeGroupID)
 		if err != nil {
 			return err
 		}
-		if params.ChangeGroupID {
-			newGroupID = append(newGroupID, []byte("++")...)
-		}
 
-		newCipherSuite := config.CipherSuite
 		if params.ChangeCipherSuite {
-			// Compute the set of ciphersuites supported by all clients
-			var supportedSuites map[uint32]bool
-			for _, client := range config.ActorClients {
-				// Initialize with the first client
-				if supportedSuites == nil {
-					supportedSuites = map[uint32]bool{}
-					for suite := range client.supported {
-						supportedSuites[suite] = true
-					}
-					continue
-				}
-
-				// Then remove suites not supported by other clients
-				for suite := range supportedSuites {
-					if !client.supported[suite] {
-						delete(supportedSuites, suite)
-					}
-				}
+			err = config.ChangeCipherSuite()
+			if err != nil {
+				return err
 			}
-
-			// Remove the current ciphersuite
-			delete(supportedSuites, config.CipherSuite)
-
-			// Select one of the remaining ones
-			if len(supportedSuites) == 0 {
-				return fmt.Errorf("No remaining supported ciphersuite")
-			}
-
-			for suite := range supportedSuites {
-				newCipherSuite = suite
-				break
-			}
-			config.CipherSuite = newCipherSuite
 		}
 
-		// Have the proposer create the Proposal
-		proposal := []byte{}
-		{
+		// Have the proposer create the Proposal or get the external proposal created
+		// earlier
+		var proposal []byte
+		if params.Proposer != "" {
 			client := config.ActorClients[params.Proposer]
 			req := &pb.ReInitProposalRequest{
 				StateId:     config.stateID[params.Proposer],
-				CipherSuite: newCipherSuite,
+				CipherSuite: config.CipherSuite,
 				GroupId:     newGroupID,
 				Extensions:  params.Extensions,
 			}
@@ -1145,6 +1179,11 @@ func (config *ScriptActorConfig) RunStep(index int, step ScriptStep) error {
 			}
 
 			proposal = resp.Proposal
+		} else {
+			proposal, err = config.GetMessage(params.ExternalReinitProposal, "proposal")
+			if err != nil {
+				return err
+			}
 		}
 
 		// Have the committer commit the Proposal and advance their state


### PR DESCRIPTION
* Complete the proposal types in `external_proposals.json`; GCE, resumption PSK and reinit were added.
* Extend the reinit action to allow using an external reint proposal created in a previous step.
* `ChangeCipherSuite` and `NewGroupID` functions are copied without changing the functionality.