### PR TITLE
Log test failure as error

### DIFF
--- a/interop/test-runner/main.go
+++ b/interop/test-runner/main.go
@@ -1713,6 +1713,13 @@ func main() {
 	chk("Error marshaling results", err)
 	fmt.Println(string(resultsJSON))
 
+	for _, results := range results.Scripts {
+		for _, result := range results {
+			if result.FailedStep != nil {
+				log.Fatal("Test failed")
+			}
+		}
+	}
 }
 
 func chk(message string, err error) {


### PR DESCRIPTION
This is useful to run the test in CI (returning 1 causes the CI to fail) and check interoperability with self.