### PR TITLE
Add a Free RPC and clean up after a script run

### DIFF
--- a/interop/proto/mls_client.proto
+++ b/interop/proto/mls_client.proto
@@ -54,6 +54,9 @@ service MLSClient {
   rpc CreateExternalSigner(CreateExternalSignerRequest) returns (CreateExternalSignerResponse) {}
   rpc AddExternalSigner(AddExternalSignerRequest) returns (ProposalResponse) {}
   rpc ExternalSignerProposal(ExternalSignerProposalRequest) returns (ProposalResponse) {}
+
+  // Cleanup
+  rpc Free(FreeRequest) returns (FreeResponse) {}
 }
 
 // rpc Name
@@ -397,3 +400,10 @@ message ExternalSignerProposalRequest{
   bytes ratchet_tree = 4;
   ProposalDescription description = 5;
 }
+
+// rpc Free
+message FreeRequest {
+  uint32 state_id = 1;
+}
+
+message FreeResponse {}

--- a/interop/test-runner/main.go
+++ b/interop/test-runner/main.go
@@ -1581,8 +1581,17 @@ func (config *ScriptActorConfig) Run(script Script) ScriptResult {
 			result.FailedStep = new(int)
 			*result.FailedStep = i
 			result.FailedStepJSON = string(step.Raw)
-			return result
+			break
 		}
+	}
+
+	// Release the resources on the clients that were created for this test
+	for actor, stateID := range config.stateID {
+		client := config.ActorClients[actor]
+		req := &pb.FreeRequest{
+			StateId: stateID,
+		}
+		client.rpc.Free(ctx(), req)
 	}
 
 	return result


### PR DESCRIPTION
Currently, the script runner tells clients under test to allocate resources (CreateKeyPackage, CreateGroup, etc.), but never tells them when those resources are no longer needed.  This PR adds a `Free()` RPC to let the client know that the resources for the test are no longer needed, and calls that RPC at the end of a script run.  Only the final state of each client is cleaned up, under the theory that (a) clients can clean up prior states as they change epochs and (b) join resources can be cleaned up once the member joins the group.