### PR TITLE
Add tree hash inside Tree Operations test vector

### DIFF
--- a/test-vectors.md
+++ b/test-vectors.md
@@ -445,23 +445,29 @@ Verification:
 Format:
 ```text
 {
+  "cipher_suite": /* uint16 */,
+
   // Chosen by the generator
   "tree_before": /* hex-encoded TLS-serialized ratchet tree */,
   "proposal": /* hex-encoded TLS-serialized Proposal */,
   "proposal_sender": /* uint32 */,
 
   // Computed values
+  "tree_hash_before": /* hex-encoded binary data */,
   "tree_after": /* hex-encoded TLS-serialized ratchet tree */,
+  "tree_hash_after": /* hex-encoded binary data */,
 }
 ```
 
 The type of `proposal` is either `add`, `remove` or `update`. 
 
 Verification:
+* Verify that the tree hash of `tree_before` matches `tree_hash_before`.
 * Compute `candidate_tree_after` by applying `proposal` sent by the member
   with index `proposal_sender` to `tree_before`.
 * Verify that serialized `candidate_tree_after` matches the provided `tree_after`
   value.
+* Verify that the tree hash of `candidate_tree_after` matches `tree_hash_after`.
 
 ## Tree Validation
 


### PR DESCRIPTION
Consider the following tree:

```
              R
        ______|______
       /             \
      _               _
    __|__           __|__
   /     \         /     \
  _       _       _       _
 / \     / \     / \     / \
A   _   _   _   _   _   _   H
```

In a test where H is removed, several implementations could have differing `candidate_tree_after` while having the same `tree_after`:

For example, if the implementation removes but forget to truncate, we would have the following tree:

```
              _
        ______|______
       /             \
      _               _
    __|__           __|__
   /     \         /     \
  _       _       _       _
 / \     / \     / \     / \
A   _   _   _   _   _   _   _
```

Or if the implementation truncate after removing, but only one level, the tree could look like this:

```
      _      
    __|__    
   /     \   
  _       _  
 / \     / \ 
A   _   _   _
```

However, in all that cases, the `tree_after` would only contain one node (`A`), because rightmost blank nodes are trimmed during the serialization.

This PR adds a tree hash, that would catch this differing behavior between the implementations.