### PR TITLE
Add Docker-based interop testing

### DIFF
--- a/docker/Dockerfile.mlspp
+++ b/docker/Dockerfile.mlspp
@@ -1,0 +1,28 @@
+FROM ubuntu:latest
+
+RUN apt-get -y update && apt-get -y install git make cmake clang curl zip pkg-config ninja-build
+
+RUN useradd -m user
+USER user
+WORKDIR /home/user
+
+# Clone MLSpp
+RUN git clone https://github.com/cisco/mlspp.git
+WORKDIR mlspp
+
+# Set up vcpkg
+ENV CMAKE_GENERATOR=Ninja
+ENV CMAKE_TOOLCHAIN_FILE=/home/user/mlspp/vcpkg/scripts/buildsystems/vcpkg.cmake
+ENV VCPKG_FORCE_SYSTEM_BINARIES=1
+RUN git submodule update --init --recursive
+RUN ./vcpkg/bootstrap-vcpkg.sh
+
+# Build MLSpp
+RUN make dev
+RUN make everything
+
+# Build the MLSpp interop harness
+WORKDIR cmd/interop
+RUN make
+
+ENTRYPOINT [ "./build/mlspp_client" ]

--- a/docker/Dockerfile.openmls
+++ b/docker/Dockerfile.openmls
@@ -1,0 +1,19 @@
+FROM rust:latest
+
+RUN apt-get -y update && apt-get -y install protobuf-compiler
+
+RUN useradd -m user
+USER user
+WORKDIR /home/user
+
+# Checkout the openmls repo
+RUN git clone https://github.com/openmls/openmls.git
+
+WORKDIR openmls/interop_client
+
+
+ENV RUST_LOG=interop=info
+
+EXPOSE 50051
+
+ENTRYPOINT [ "cargo", "run", "--" ]

--- a/docker/Dockerfile.test-runner
+++ b/docker/Dockerfile.test-runner
@@ -21,10 +21,18 @@ RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
 # Import this repo into the container
 COPY --chown=user . mls-implementations
+ 
+# Generate the Go interface from the proto files
+WORKDIR mls-implementations/interop
+RUN protoc --go_out=proto \
+           --go_opt=paths=source_relative \
+           --go-grpc_out=proto \
+           --go-grpc_opt=paths=source_relative \
+           -I proto \
+           mls_client.proto
 
 # Build the test runner
-WORKDIR mls-implementations/interop/test-runner
-RUN go mod tidy -e
+WORKDIR test-runner
 RUN go build
 
 ENTRYPOINT [ "./test-runner" ]

--- a/docker/Dockerfile.test-runner
+++ b/docker/Dockerfile.test-runner
@@ -33,6 +33,7 @@ RUN protoc --go_out=proto \
 
 # Build the test runner
 WORKDIR test-runner
+RUN go mod tidy
 RUN go build
 
 ENTRYPOINT [ "./test-runner" ]

--- a/docker/Dockerfile.test-runner
+++ b/docker/Dockerfile.test-runner
@@ -1,0 +1,30 @@
+# This Dockerfile MUST be built with the build context set to be the root of the
+# mls-implementations repo.
+#
+# > docker build -f docker/test-runner/Dockerfile .
+#
+# Once this is built, you can run
+FROM ubuntu:latest
+
+RUN apt-get -y update && apt-get -y install git make golang protoc-gen-go
+
+RUN useradd -m user
+USER user
+WORKDIR /home/user
+
+# Set up Go prerequisites
+ENV GOPATH=/home/user/go
+ENV PATH=$PATH:$GOPATH/bin
+
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
+# Import this repo into the container
+COPY --chown=user . mls-implementations
+
+# Build the test runner
+WORKDIR mls-implementations/interop/test-runner
+RUN go mod tidy -e
+RUN go build
+
+ENTRYPOINT [ "./test-runner" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,32 @@
+Docker Interop Tooling
+======================
+
+This directory contains docker files to facilitate interop testing among
+different stacks.  There is a Dockerfile for each implementation, and one for
+the test runner script.  The `docker-compose.yml` file connects the
+implementation with the test runner and runs a test config.  You can edit the
+docker-compose file to plug in different implementations or run different test
+configs.
+
+## Running tests
+
+```
+# Run the tests (after building the containers if necessary)
+> docker-compose up
+```
+
+The first run will take several minutes, as Docker sets up the containers and
+builds the implementations.  After that, running the compose script should only
+take as long as it takes to run the tests.  You may have to manually kill the
+compose script (`Ctrl-C`), since the implementation containers will keep running
+until killed.
+
+## Adding an implementation
+
+If you want to add your stack to this testing scheme, please submit a PR that
+does the following:
+
+* Add a Dockerfile named `Dockerfile.<name>` that clones your repo, builds the
+  implementation, and starts the interop harness.
+
+* Add a service to `docker-compose.yml` to run your implementation.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,16 @@
+---
+name: mls-interop
+services:
+  mlspp:
+    build: 
+      dockerfile: ./Dockerfile.mlspp
+    ports:
+      - 50052:${MLSPP_PORT:-50052}
+    command: -live ${MLSPP_PORT:-50052}
+  test-runner:
+    build:
+      # Note that the context must be '..' so that the `interop` directory can
+      # be copied into the container.
+      context: ..
+      dockerfile: ./docker/Dockerfile.test-runner
+    command: -fail-fast -client mlspp:${MLSPP_PORT:-50052} -config=../configs/${CONFIG_RUN:-welcome_join.json}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,8 +1,14 @@
 ---
 name: mls-interop
 services:
+  openmls:
+    build:
+      dockerfile: ./Dockerfile.openmls
+    ports:
+      - 50051:${OPENMLS_PORT:-50051}
+    command: -p ${OPENMLS_PORT:-50051}
   mlspp:
-    build: 
+    build:
       dockerfile: ./Dockerfile.mlspp
     ports:
       - 50052:${MLSPP_PORT:-50052}
@@ -13,4 +19,4 @@ services:
       # be copied into the container.
       context: ..
       dockerfile: ./docker/Dockerfile.test-runner
-    command: -fail-fast -client mlspp:${MLSPP_PORT:-50052} -config=../configs/${CONFIG_RUN:-welcome_join.json}
+    command: -fail-fast -client openmls:${OPENMLS_PORT:-50051} -client mlspp:${MLSPP_PORT:-50052} -config=../configs/${CONFIG_RUN:-welcome_join.json}


### PR DESCRIPTION
In our interop call today, we agreed that it would be helpful to add some Docker tooling to let people do interop testing more easily.  This PR adds Dockerfiles for the test runner and for MLSpp, with the idea that this should allow other folks to send PRs adding their stacks.

Inspired by the [OpenMLS docker tooling](https://github.com/openmls/openmls/tree/main/interop_client/docker).